### PR TITLE
Add configuration

### DIFF
--- a/src/main/scala/AtomRenderer.scala
+++ b/src/main/scala/AtomRenderer.scala
@@ -104,8 +104,11 @@ object ArticleAtomRenderer extends AtomRenderer {
   type Conf = NilConfiguration
   val renderings = renderers.ArticleRenderings
 
+  @deprecated("will be removed", "atom-renderer 0.10")
   def getHTML(atom: Atom): HTML = getHTML(atom, NilConfiguration)
+  @deprecated("will be removed", "atom-renderer 0.10")
   def getHTML(json: Json): Option[HTML] = getHTML(json, NilConfiguration)
+  @deprecated("will be removed", "atom-renderer 0.10")
   def getHTML(json: String): Option[HTML] = getHTML(json, NilConfiguration)
 }
 
@@ -113,7 +116,10 @@ object DefaultAtomRenderer extends AtomRenderer {
   type Conf = NilConfiguration
   val renderings = renderers.DefaultRenderings
 
+  @deprecated("will be removed", "atom-renderer 0.10")
   def getHTML(atom: Atom): HTML = getHTML(atom, NilConfiguration)
+  @deprecated("will be removed", "atom-renderer 0.10")
   def getHTML(json: Json): Option[HTML] = getHTML(json, NilConfiguration)
+  @deprecated("will be removed", "atom-renderer 0.10")
   def getHTML(json: String): Option[HTML] = getHTML(json, NilConfiguration)
 }

--- a/src/main/scala/AtomRenderer.scala
+++ b/src/main/scala/AtomRenderer.scala
@@ -22,36 +22,38 @@ trait AtomRenderer {
   import renderings._
   import json._
 
+  type Conf <: Configuration
+
   type HTML = String
   type CSS = Option[String]
   type JS = Option[String]
 
-  def getHTML[A](atom: Atom, data: A)(implicit reader: Rendering[A]): HTML =
+  def getHTML[A](atom: Atom, data: A, conf: Conf)(implicit reader: Rendering[A]): HTML =
     reader.html(atom, data).toString
   
-  def getHTML(atom: Atom): HTML = atom.data match {
-    case AtomData.Cta(data)            => getHTML(atom, data)
-    case AtomData.Explainer(data)      => getHTML(atom, data)
-    case AtomData.Guide(data)          => getHTML(atom, data)
-    case AtomData.Interactive(data)    => getHTML(atom, data)
-    case AtomData.Media(data)          => getHTML(atom, data)
-    case AtomData.Profile (data)       => getHTML(atom, data)
-    case AtomData.Qanda(data)          => getHTML(atom, data)
-    case AtomData.Quiz(data)           => getHTML(atom, data)
-    case AtomData.Recipe(data)         => getHTML(atom, data)
-    case AtomData.Review(data)         => getHTML(atom, data)
-    case AtomData.Storyquestions(data) => getHTML(atom, data)
-    case AtomData.Timeline(data)       => getHTML(atom, data)
+  def getHTML(atom: Atom, conf: Conf): HTML = atom.data match {
+    case AtomData.Cta(data)            => getHTML(atom, data, conf)
+    case AtomData.Explainer(data)      => getHTML(atom, data, conf)
+    case AtomData.Guide(data)          => getHTML(atom, data, conf)
+    case AtomData.Interactive(data)    => getHTML(atom, data, conf)
+    case AtomData.Media(data)          => getHTML(atom, data, conf)
+    case AtomData.Profile (data)       => getHTML(atom, data, conf)
+    case AtomData.Qanda(data)          => getHTML(atom, data, conf)
+    case AtomData.Quiz(data)           => getHTML(atom, data, conf)
+    case AtomData.Recipe(data)         => getHTML(atom, data, conf)
+    case AtomData.Review(data)         => getHTML(atom, data, conf)
+    case AtomData.Storyquestions(data) => getHTML(atom, data, conf)
+    case AtomData.Timeline(data)       => getHTML(atom, data, conf)
     case _                             => atom.defaultHtml
   }
 
-  def getHTML(json: Json): Option[HTML] = json.as[Atom] match {
+  def getHTML(json: Json, conf: Conf): Option[HTML] = json.as[Atom] match {
     case Left(_) => None
-    case Right(atom) => Some(getHTML(atom))
+    case Right(atom) => Some(getHTML(atom, conf))
   }
 
-  def getHTML(json: String): Option[HTML] =
-    parse(json).right.toOption.flatMap(getHTML)
+  def getHTML(json: String, conf: Conf): Option[HTML] =
+    parse(json).right.toOption.flatMap(getHTML(_, conf))
 
   def getCSS[A](implicit reader: Rendering[A]): CSS =
     reader.css.map(_.toString)
@@ -99,9 +101,19 @@ trait AtomRenderer {
 }
 
 object ArticleAtomRenderer extends AtomRenderer {
+  type Conf = NilConfiguration
   val renderings = renderers.ArticleRenderings
+
+  def getHTML(atom: Atom): HTML = getHTML(atom, NilConfiguration)
+  def getHTML(json: Json): Option[HTML] = getHTML(json, NilConfiguration)
+  def getHTML(json: String): Option[HTML] = getHTML(json, NilConfiguration)
 }
 
 object DefaultAtomRenderer extends AtomRenderer {
+  type Conf = NilConfiguration
   val renderings = renderers.DefaultRenderings
+
+  def getHTML(atom: Atom): HTML = getHTML(atom, NilConfiguration)
+  def getHTML(json: Json): Option[HTML] = getHTML(json, NilConfiguration)
+  def getHTML(json: String): Option[HTML] = getHTML(json, NilConfiguration)
 }

--- a/src/main/scala/Configuration.scala
+++ b/src/main/scala/Configuration.scala
@@ -1,0 +1,6 @@
+package com.gu.contentatom.renderer
+
+sealed trait Configuration
+
+sealed trait NilConfiguration extends Configuration
+case object NilConfiguration extends NilConfiguration


### PR DESCRIPTION
Seed for customizing atom rendering. No configuration is being used right now but ultimately each atom type will have its own specific configuration class (so that the type system helps us prevent missing data) and the overloaded methods I added will be removed.

This will become helpful for a list of scenarios, for instance:

- interacting with 3rd party services, like imgIX to generate optimized responsive images in a secure setting
- sharing properties that should remain hidden from the outside world, like private URLs, passwords, etc.
- provide platform-specific rendering without any form of complecting