### PR TITLE
Fix multine border on Safari

### DIFF
--- a/src/main/resources/css/atoms/_snippet.scss
+++ b/src/main/resources/css/atoms/_snippet.scss
@@ -40,7 +40,7 @@
     display: block;
 
     .content--pillar-news      & { color: var(--c-pillar-news); }
-    .content--pillar-culture   & { color: var(--c-pillar-culture); }
+    .content--pillar-arts      & { color: var(--c-pillar-arts); }
     .content--pillar-sport     & { color: var(--c-pillar-sport); }
     .content--pillar-opinion   & { color: var(--c-pillar-opinion); }
     .content--pillar-lifestyle & { color: var(--c-pillar-lifestyle); }
@@ -78,7 +78,7 @@
 .atom--snippet__handle:hover,
 .atom--snippet__handle:focus {
     .content--pillar-news      & { background-color: var(--c-pillar-news); }
-    .content--pillar-culture   & { background-color: var(--c-pillar-culture); }
+    .content--pillar-arts      & { background-color: var(--c-pillar-arts); }
     .content--pillar-sport     & { background-color: var(--c-pillar-sport); }
     .content--pillar-opinion   & { background-color: var(--c-pillar-opinion); }
     .content--pillar-lifestyle & { background-color: var(--c-pillar-lifestyle); }    

--- a/src/main/resources/css/atoms/_snippet.scss
+++ b/src/main/resources/css/atoms/_snippet.scss
@@ -12,6 +12,9 @@
 
 .atom--snippet {
     @include multiline(4, $neutral-4);
+    border-left: 0;
+    border-right: 0;
+    border-bottom: 0;
     background: $neutral-7;
     position: relative;
     padding: 0 ($gutter / 4) ($baseline / 2);

--- a/src/main/resources/css/atoms/_snippet.scss
+++ b/src/main/resources/css/atoms/_snippet.scss
@@ -39,10 +39,15 @@
 .atom--snippet__label {
     display: block;
 
+    .garnett--pillar-news      &,
     .content--pillar-news      & { color: var(--c-pillar-news); }
+    .garnett--pillar-arts      &,
     .content--pillar-arts      & { color: var(--c-pillar-arts); }
+    .garnett--pillar-sport     &,
     .content--pillar-sport     & { color: var(--c-pillar-sport); }
+    .garnett--pillar-opinion   &,
     .content--pillar-opinion   & { color: var(--c-pillar-opinion); }
+    .garnett--pillar-lifestyle &,
     .content--pillar-lifestyle & { color: var(--c-pillar-lifestyle); }
 }
 
@@ -77,10 +82,15 @@
 .atom--snippet__feedback .atom__button:focus,
 .atom--snippet__handle:hover,
 .atom--snippet__handle:focus {
+    .garnett--pillar-news      &,
     .content--pillar-news      & { background-color: var(--c-pillar-news); }
+    .garnett--pillar-arts      &,
     .content--pillar-arts      & { background-color: var(--c-pillar-arts); }
+    .garnett--pillar-sport     &,
     .content--pillar-sport     & { background-color: var(--c-pillar-sport); }
+    .garnett--pillar-opinion   &,
     .content--pillar-opinion   & { background-color: var(--c-pillar-opinion); }
+    .garnett--pillar-lifestyle &,
     .content--pillar-lifestyle & { background-color: var(--c-pillar-lifestyle); }    
 }
 

--- a/src/main/resources/css/helpers/_multiline.scss
+++ b/src/main/resources/css/helpers/_multiline.scss
@@ -6,6 +6,6 @@
                                           $lc 1px,
                                           transparent 1px,
                                           transparent 4px) $size;
-  border-#{$p}: #{$size}px solid transparent;
+  border-#{$p}: #{$size}px solid black;
 }
 

--- a/src/main/resources/storyquestions/article/index.scss
+++ b/src/main/resources/storyquestions/article/index.scss
@@ -16,10 +16,15 @@
   font-weight: 500;
   margin-bottom: 0;
 
+  .garnett--pillar-news      &,
   .content--pillar-news      & { color: var(--c-pillar-news); }
+  .garnett--pillar-arts      &,
   .content--pillar-arts      & { color: var(--c-pillar-arts); }
+  .garnett--pillar-sport     &,
   .content--pillar-sport     & { color: var(--c-pillar-sport); }
+  .garnett--pillar-opinion   &,
   .content--pillar-opinion   & { color: var(--c-pillar-opinion); }
+  .garnett--pillar-lifestyle &,
   .content--pillar-lifestyle & { color: var(--c-pillar-lifestyle); }
 }
 
@@ -65,10 +70,15 @@
     background: #fcfcfc;
     
     .atom__button {
+      .garnett--pillar-news      &,
       .content--pillar-news      & { background-color: var(--c-pillar-news); }
+      .garnett--pillar-arts      &,
       .content--pillar-arts      & { background-color: var(--c-pillar-arts); }
+      .garnett--pillar-sport     &,
       .content--pillar-sport     & { background-color: var(--c-pillar-sport); }
+      .garnett--pillar-opinion   &,
       .content--pillar-opinion   & { background-color: var(--c-pillar-opinion); }
+      .garnett--pillar-lifestyle &,
       .content--pillar-lifestyle & { background-color: var(--c-pillar-lifestyle); }
     }
   }
@@ -122,10 +132,15 @@
 
   &:hover,
   &:active {
+    .garnett--pillar-news      &,
     .content--pillar-news      & { background-color: var(--c-pillar-news); }
+    .garnett--pillar-arts      &,
     .content--pillar-arts      & { background-color: var(--c-pillar-arts); }
+    .garnett--pillar-sport     &,
     .content--pillar-sport     & { background-color: var(--c-pillar-sport); }
+    .garnett--pillar-opinion   &,
     .content--pillar-opinion   & { background-color: var(--c-pillar-opinion); }
+    .garnett--pillar-lifestyle &,
     .content--pillar-lifestyle & { background-color: var(--c-pillar-lifestyle); }    
   }
 }

--- a/src/main/resources/storyquestions/article/index.scss
+++ b/src/main/resources/storyquestions/article/index.scss
@@ -17,7 +17,7 @@
   margin-bottom: 0;
 
   .content--pillar-news      & { color: var(--c-pillar-news); }
-  .content--pillar-culture   & { color: var(--c-pillar-culture); }
+  .content--pillar-arts      & { color: var(--c-pillar-arts); }
   .content--pillar-sport     & { color: var(--c-pillar-sport); }
   .content--pillar-opinion   & { color: var(--c-pillar-opinion); }
   .content--pillar-lifestyle & { color: var(--c-pillar-lifestyle); }
@@ -66,7 +66,7 @@
     
     .atom__button {
       .content--pillar-news      & { background-color: var(--c-pillar-news); }
-      .content--pillar-culture   & { background-color: var(--c-pillar-culture); }
+      .content--pillar-arts      & { background-color: var(--c-pillar-arts); }
       .content--pillar-sport     & { background-color: var(--c-pillar-sport); }
       .content--pillar-opinion   & { background-color: var(--c-pillar-opinion); }
       .content--pillar-lifestyle & { background-color: var(--c-pillar-lifestyle); }
@@ -123,7 +123,7 @@
   &:hover,
   &:active {
     .content--pillar-news      & { background-color: var(--c-pillar-news); }
-    .content--pillar-culture   & { background-color: var(--c-pillar-culture); }
+    .content--pillar-arts      & { background-color: var(--c-pillar-arts); }
     .content--pillar-sport     & { background-color: var(--c-pillar-sport); }
     .content--pillar-opinion   & { background-color: var(--c-pillar-opinion); }
     .content--pillar-lifestyle & { background-color: var(--c-pillar-lifestyle); }    


### PR DESCRIPTION
Safari needs extra care with borders: `border-image` works correctly only when the `border-color` is not transparent, and one should make sure the `border-width`s are explicitly set.

Also reverting the renaming of 'arts' into 'culture' as even thought the pillar was renamed, its label is _still_ the same _but_ the SASS var in frontend _has been_ renamed, and this is where I got lost 😲 

Checked with apps: both frontend and apps will identify the culture pillar as arts.