### PR TITLE
Explainer: Add code for rendering explainers 

### DIFF
--- a/src/main/resources/explainer/article/index.scala.html
+++ b/src/main/resources/explainer/article/index.scala.html
@@ -3,3 +3,10 @@
 )
 
 
+<div class="atom atom--explainer"> 
+  <h4 class="atom--explainer__header"> 
+    @data.title
+  </h4> 
+  @Html(data.body)
+</div>
+

--- a/src/main/resources/explainer/article/index.scss
+++ b/src/main/resources/explainer/article/index.scss
@@ -1,0 +1,22 @@
+@import "vars";
+
+.explainer {
+    padding: $baseline / 2 $gutter / 4;
+    background-color: $guardian-brand;
+    color: #ffffff;
+    position: relative;
+}
+
+.explainer__header {
+    font-size: 20px;
+    line-height: 24px;
+    font-weight: 900;
+    min-height: 24px;
+    padding-bottom: $baseline * 1.5;
+}
+
+ol, p, ul {
+    font-size: 14px;
+    line-height: 20px;
+    margin: 0 0 $baseline / 2;
+}


### PR DESCRIPTION
In order to support explainers in old articles, we want this library to be able to render them.
This adds the CSS and Html templates to render them. 

A separate pull request in CAPI will change the html to use the `gu-tools` format and not the interactive one. 

NB: We are stripping the feedback buttons out. 

[Article with an explainer example](https://www.theguardian.com/world/2017/sep/05/azerbaijani-laundromat-shows-how-regime-robs-its-people-to-feed-itself)

[Trello ticket](https://trello.com/c/Qa9XYPhG/173-kill-the-old-explainer-part-2) 