### PR TITLE
Fix: add atom type explainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/atom-renderer",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Platform-agnostic rendering library for atoms",
   "repository": "https://github.com/guardian/atom-renderer.git",
   "author": "Regis Kuckaertz <regis.kuckaertz@theguardian.com>",

--- a/src/main/resources/__flow__/types/atoms.fjs
+++ b/src/main/resources/__flow__/types/atoms.fjs
@@ -5,7 +5,8 @@ declare type AtomType =
   | 'profile'
   | 'qanda'
   | 'timeline'
-  | 'storyquestions';
+  | 'storyquestions'
+  | 'explainer';
 
 declare type Atom = { atomId: string
                     , start: (a: Atom) => Promise<void>

--- a/webpack/atomTypes.js
+++ b/webpack/atomTypes.js
@@ -1,1 +1,1 @@
-module.exports = ['guide', 'qanda', 'profile', 'timeline', 'storyquestions'];
+module.exports = ['guide', 'qanda', 'profile', 'timeline', 'storyquestions', 'explainer'];


### PR DESCRIPTION
We need to add the 'explainer' atom to the list of types exported by Atom Renderer. 