### PR TITLE
Add SASS vars for pillar colours

### DIFF
--- a/src/main/resources/css/_vars.scss
+++ b/src/main/resources/css/_vars.scss
@@ -13,6 +13,13 @@ $mq-breakpoints: (
 $baseline :               12px;
 $gutter :                 20px;
 
+/* pillar colours */
+$c-pillar--news      : #e00000;
+$c-pillar--opinion   : #ed6300;
+$c-pillar--sport     : #0084c6;
+$c-pillar--arts      : #ab8958;
+$c-pillar--lifestyle : #bb3b80;
+
 /* colours */
 $guardian-brand :         #005689;
 $guardian-brand-light :   #94b1ca;

--- a/src/main/resources/css/atoms/_snippet.scss
+++ b/src/main/resources/css/atoms/_snippet.scss
@@ -40,15 +40,15 @@
     display: block;
 
     .garnett--pillar-news      &,
-    .content--pillar-news      & { color: var(--c-pillar-news); }
+    .content--pillar-news      & { color: $c-pillar--news; }
     .garnett--pillar-arts      &,
-    .content--pillar-arts      & { color: var(--c-pillar-arts); }
+    .content--pillar-arts      & { color: $c-pillar--arts; }
     .garnett--pillar-sport     &,
-    .content--pillar-sport     & { color: var(--c-pillar-sport); }
+    .content--pillar-sport     & { color: $c-pillar--sport; }
     .garnett--pillar-opinion   &,
-    .content--pillar-opinion   & { color: var(--c-pillar-opinion); }
+    .content--pillar-opinion   & { color: $c-pillar--opinion; }
     .garnett--pillar-lifestyle &,
-    .content--pillar-lifestyle & { color: var(--c-pillar-lifestyle); }
+    .content--pillar-lifestyle & { color: $c-pillar--lifestyle; }
 }
 
 .atom--snippet__label,
@@ -83,15 +83,15 @@
 .atom--snippet__handle:hover,
 .atom--snippet__handle:focus {
     .garnett--pillar-news      &,
-    .content--pillar-news      & { background-color: var(--c-pillar-news); }
+    .content--pillar-news      & { background-color: $c-pillar--news; }
     .garnett--pillar-arts      &,
-    .content--pillar-arts      & { background-color: var(--c-pillar-arts); }
+    .content--pillar-arts      & { background-color: $c-pillar--arts; }
     .garnett--pillar-sport     &,
-    .content--pillar-sport     & { background-color: var(--c-pillar-sport); }
+    .content--pillar-sport     & { background-color: $c-pillar--sport; }
     .garnett--pillar-opinion   &,
-    .content--pillar-opinion   & { background-color: var(--c-pillar-opinion); }
+    .content--pillar-opinion   & { background-color: $c-pillar--opinion; }
     .garnett--pillar-lifestyle &,
-    .content--pillar-lifestyle & { background-color: var(--c-pillar-lifestyle); }    
+    .content--pillar-lifestyle & { background-color: $c-pillar--lifestyle; }    
 }
 
 .atom--snippet__handle span {

--- a/src/main/resources/storyquestions/article/index.scss
+++ b/src/main/resources/storyquestions/article/index.scss
@@ -17,15 +17,15 @@
   margin-bottom: 0;
 
   .garnett--pillar-news      &,
-  .content--pillar-news      & { color: var(--c-pillar-news); }
+  .content--pillar-news      & { color: $c-pillar--news; }
   .garnett--pillar-arts      &,
-  .content--pillar-arts      & { color: var(--c-pillar-arts); }
+  .content--pillar-arts      & { color: $c-pillar--arts; }
   .garnett--pillar-sport     &,
-  .content--pillar-sport     & { color: var(--c-pillar-sport); }
+  .content--pillar-sport     & { color: $c-pillar--sport; }
   .garnett--pillar-opinion   &,
-  .content--pillar-opinion   & { color: var(--c-pillar-opinion); }
+  .content--pillar-opinion   & { color: $c-pillar--opinion; }
   .garnett--pillar-lifestyle &,
-  .content--pillar-lifestyle & { color: var(--c-pillar-lifestyle); }
+  .content--pillar-lifestyle & { color: $c-pillar--lifestyle; }
 }
 
 .atom--readerquestions .atom--readerquestions__description {
@@ -71,15 +71,15 @@
     
     .atom__button {
       .garnett--pillar-news      &,
-      .content--pillar-news      & { background-color: var(--c-pillar-news); }
+      .content--pillar-news      & { background-color: $c-pillar--news; }
       .garnett--pillar-arts      &,
-      .content--pillar-arts      & { background-color: var(--c-pillar-arts); }
+      .content--pillar-arts      & { background-color: $c-pillar--arts; }
       .garnett--pillar-sport     &,
-      .content--pillar-sport     & { background-color: var(--c-pillar-sport); }
+      .content--pillar-sport     & { background-color: $c-pillar--sport; }
       .garnett--pillar-opinion   &,
-      .content--pillar-opinion   & { background-color: var(--c-pillar-opinion); }
+      .content--pillar-opinion   & { background-color: $c-pillar--opinion; }
       .garnett--pillar-lifestyle &,
-      .content--pillar-lifestyle & { background-color: var(--c-pillar-lifestyle); }
+      .content--pillar-lifestyle & { background-color: $c-pillar--lifestyle; }
     }
   }
 }
@@ -133,15 +133,15 @@
   &:hover,
   &:active {
     .garnett--pillar-news      &,
-    .content--pillar-news      & { background-color: var(--c-pillar-news); }
+    .content--pillar-news      & { background-color: $c-pillar--news; }
     .garnett--pillar-arts      &,
-    .content--pillar-arts      & { background-color: var(--c-pillar-arts); }
+    .content--pillar-arts      & { background-color: $c-pillar--arts; }
     .garnett--pillar-sport     &,
-    .content--pillar-sport     & { background-color: var(--c-pillar-sport); }
+    .content--pillar-sport     & { background-color: $c-pillar--sport; }
     .garnett--pillar-opinion   &,
-    .content--pillar-opinion   & { background-color: var(--c-pillar-opinion); }
+    .content--pillar-opinion   & { background-color: $c-pillar--opinion; }
     .garnett--pillar-lifestyle &,
-    .content--pillar-lifestyle & { background-color: var(--c-pillar-lifestyle); }    
+    .content--pillar-lifestyle & { background-color: $c-pillar--lifestyle; }    
   }
 }
 


### PR DESCRIPTION
Until the apps have done the CSS var substitution for pillar colours, we encode them in our local vars. This to prevent display bugs, esp. with buttons, in android and ios.