### PR TITLE
Fix Explainer CSS & default JS export 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/atom-renderer",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Platform-agnostic rendering library for atoms",
   "repository": "https://github.com/guardian/atom-renderer.git",
   "author": "Regis Kuckaertz <regis.kuckaertz@theguardian.com>",

--- a/src/main/resources/explainer/article/index.fjs
+++ b/src/main/resources/explainer/article/index.fjs
@@ -1,1 +1,11 @@
 //@flow
+// mock atom type for explainers 
+
+export default (services: Services) =>  (html: HTMLElement): Coeval<Atom> => ({ 
+  runTry: () => ({
+    start: () => Promise.resolve(),
+    stop: () => {},
+    atomId: ""
+  })
+})
+

--- a/src/main/resources/explainer/article/index.scss
+++ b/src/main/resources/explainer/article/index.scss
@@ -1,13 +1,13 @@
 @import "vars";
 
-.explainer {
+.atom--explainer {
     padding: $baseline / 2 $gutter / 4;
     background-color: $guardian-brand;
     color: #ffffff;
     position: relative;
 }
 
-.explainer__header {
+.atom--explainer__header {
     font-size: 20px;
     line-height: 24px;
     font-weight: 900;
@@ -15,8 +15,10 @@
     padding-bottom: $baseline * 1.5;
 }
 
-ol, p, ul {
+.atom--explainer {
+  ol, p, ul {
     font-size: 14px;
     line-height: 20px;
     margin: 0 0 $baseline / 2;
+  }
 }


### PR DESCRIPTION
The Default export for the JS needs to be mocked out 
The CSS classes were wrong