### PR TITLE
Update document output settings to produce XML

### DIFF
--- a/core/src/main/scala/renderers/email/Hydrator.scala
+++ b/core/src/main/scala/renderers/email/Hydrator.scala
@@ -43,7 +43,9 @@ object Hydrator {
     val doc = document(html)
     val rules = stylesheet(css)
     rules.foreach(run(doc, _)) // ಥ﹏ಥ
-    doc.charset(java.nio.charset.StandardCharsets.UTF_8)
+    doc
+      .outputSettings(doc.outputSettings.syntax(Document.OutputSettings.Syntax.xml))
+      .charset(java.nio.charset.StandardCharsets.UTF_8)
     doc.body.html
   }
 


### PR DESCRIPTION
Exact Target expects fully-formed XML, but the atom renderer produces HTML. Fortunately, JSOUP provides the ability to choose the syntax of the output. This changes makes sure whatever is output by the email renderer will be XML-compliant.