### PR TITLE
Fix: Surround each snippet with email skeleton

### DIFF
--- a/core/src/main/resources/profile/email/index.scala.html
+++ b/core/src/main/resources/profile/email/index.scala.html
@@ -2,48 +2,50 @@
 , data: com.gu.contentatom.thrift.atom.profile.ProfileAtom
 )(implicit conf: com.gu.contentatom.renderer.EmailConfiguration)
 
-@fragments.email.html.snippet( 
-  atom, 
-  className = "profile", 
-  label = data.typeLabel.getOrElse("Profile"), 
-  headline = atom.title.getOrElse("")
-){ 
-  <table cellspacing="0" cellpadding="0" border="0">
-    <tr>
-      <td width="100">
-        @for(
-          img <- data.headshot 
-        ) { 
-          @fragments.atoms.html.snippetImage(img) 
-        }
-      </td>
-      <td width="10"></td>
-      <td width="470">
-        @for(
-          item <- data.items
-        ) { 
-          <div class="atom--snippet__item">
-            @item.title.map { t =>
-              <div class="atom--snippet__heading">
-                <b>@t</b>
-              </div>
-            } 
-            @Html(item.body)
-          </div>
-        } 
-      </td>
-    </tr>
-  
-    @for( 
-      img <- data.headshot; 
-      asset <- img.master; 
-      credit <- asset.credit 
-    ) {
-      <tr> 
-        <td colspan="3" class="atom--snippet__credit">
-          @credit
+@fragments.email.html.email(atom){
+  @fragments.email.html.snippet( 
+    atom, 
+    className = "profile", 
+    label = data.typeLabel.getOrElse("Profile"), 
+    headline = atom.title.getOrElse("")
+  ){ 
+    <table cellspacing="0" cellpadding="0" border="0">
+      <tr>
+        <td width="100">
+          @for(
+            img <- data.headshot 
+          ) { 
+            @fragments.atoms.html.snippetImage(img) 
+          }
+        </td>
+        <td width="10"></td>
+        <td width="470">
+          @for(
+            item <- data.items
+          ) { 
+            <div class="atom--snippet__item">
+              @item.title.map { t =>
+                <div class="atom--snippet__heading">
+                  <b>@t</b>
+                </div>
+              } 
+              @Html(item.body)
+            </div>
+          } 
         </td>
       </tr>
-    } 
-  </table>
+    
+      @for( 
+        img <- data.headshot; 
+        asset <- img.master; 
+        credit <- asset.credit 
+      ) {
+        <tr> 
+          <td colspan="3" class="atom--snippet__credit">
+            @credit
+          </td>
+        </tr>
+      } 
+    </table>
+  }
 }

--- a/core/src/main/resources/qanda/email/index.scala.html
+++ b/core/src/main/resources/qanda/email/index.scala.html
@@ -2,37 +2,39 @@
 , data: com.gu.contentatom.thrift.atom.qanda.QAndAAtom
 )(implicit conf: com.gu.contentatom.renderer.EmailConfiguration)
 
-@fragments.email.html.snippet( 
-  atom, 
-  className = "qanda", 
-  label = data.typeLabel.getOrElse("Q&amp;A"), 
-  headline = atom.title.getOrElse("")
-){ 
-  <table cellspacing="0" cellpadding="0" border="0">
-    <tr>
-      <td width="100">
-        @for(
-          img <- data.eventImage 
-        ) { 
-          @fragments.atoms.html.snippetImage(img)
-        } 
-      </td>
-      <td width="10"></td>
-      <td width="470">
-        @Html(data.item.body) 
-      </td>
-    </tr>
-    
-    @for( 
-      img <- data.eventImage;
-      asset <- img.master; 
-      credit <- asset.credit 
-    ) { 
+@fragments.email.html.email(atom){
+  @fragments.email.html.snippet( 
+    atom, 
+    className = "qanda", 
+    label = data.typeLabel.getOrElse("Q&amp;A"), 
+    headline = atom.title.getOrElse("")
+  ){ 
+    <table cellspacing="0" cellpadding="0" border="0">
       <tr>
-        <td colspan="3" class="atom--snippet__credit">
-          @credit
+        <td width="100">
+          @for(
+            img <- data.eventImage 
+          ) { 
+            @fragments.atoms.html.snippetImage(img)
+          } 
+        </td>
+        <td width="10"></td>
+        <td width="470">
+          @Html(data.item.body) 
         </td>
       </tr>
-    }
-  </table>
+      
+      @for( 
+        img <- data.eventImage;
+        asset <- img.master; 
+        credit <- asset.credit 
+      ) { 
+        <tr>
+          <td colspan="3" class="atom--snippet__credit">
+            @credit
+          </td>
+        </tr>
+      }
+    </table>
+  }
 }

--- a/core/src/main/resources/timeline/email/index.scala.html
+++ b/core/src/main/resources/timeline/email/index.scala.html
@@ -5,34 +5,36 @@
 , data: com.gu.contentatom.thrift.atom.timeline.TimelineAtom
 )(implicit conf: com.gu.contentatom.renderer.EmailConfiguration)
 
-@fragments.email.html.snippet(
-  atom, 
-  className = "timeline", 
-  label = data.typeLabel.getOrElse("Timeline"), 
-  headline = atom.title.getOrElse("") 
-){
-  <table width="100%" cellspacing="0" cellpadding="0" border="0">
-    @for(
-      description <- data.description
-    ) {
-      <tr><td class="atom--snippet__description">@Html(description)</td></tr>      
-    } 
-    
-    @for(
-      item <- data.events
-    ) { 
-      <tr class="atom--snippet__item">
-        <td class="atom--snippet__event-date">
-          <span>@item.renderFormattedDate(item.date, item.dateFormat)</span>
-          @item.toDate.map { maybeDate => –
-            <span>@item.renderFormattedDate(maybeDate, item.dateFormat)</span>
-          }
-        </td>
-      </tr>
-      <tr><td class="atom--snippet__heading"><b>@item.title</b></td></tr>
-      @item.body.map { body =>
-        <tr><td class="atom--snippet__body">@Html(body)</td></tr>
-      }
-    } 
-  </table>
+@fragments.email.html.email(atom){
+  @fragments.email.html.snippet(
+    atom, 
+    className = "timeline", 
+    label = data.typeLabel.getOrElse("Timeline"), 
+    headline = atom.title.getOrElse("") 
+  ){
+    <table width="100%" cellspacing="0" cellpadding="0" border="0">
+      @for(
+        description <- data.description
+      ) {
+        <tr><td class="atom--snippet__description">@Html(description)</td></tr>      
+      } 
+      
+      @for(
+        item <- data.events
+      ) { 
+        <tr class="atom--snippet__item">
+          <td class="atom--snippet__event-date">
+            <span>@item.renderFormattedDate(item.date, item.dateFormat)</span>
+            @item.toDate.map { maybeDate => –
+              <span>@item.renderFormattedDate(maybeDate, item.dateFormat)</span>
+            }
+          </td>
+        </tr>
+        <tr><td class="atom--snippet__heading"><b>@item.title</b></td></tr>
+        @item.body.map { body =>
+          <tr><td class="atom--snippet__body">@Html(body)</td></tr>
+        }
+      } 
+    </table>
+  }
 }


### PR DESCRIPTION
In email, all snippets must be wrapped inside a master table that sets the general layout of the email.

(I surrounded each fragment by `fragment.email(atom)`, is all)