### PR TITLE
Pillar color provided by platform

### DIFF
--- a/core/src/main/resources/commonsdivision/article/index.scss
+++ b/core/src/main/resources/commonsdivision/article/index.scss
@@ -118,7 +118,7 @@
 }
 
 .atom--commonsdivision__totals-header {
-  color: $c-pillar--news;
+  color: var(--c-pillar--main);
 }
 
 .atom--commonsdivision__table .atom--commonsdivision__party-mps {

--- a/core/src/main/resources/css/_vars.scss
+++ b/core/src/main/resources/css/_vars.scss
@@ -13,13 +13,6 @@ $mq-breakpoints: (
 $baseline :               12px;
 $gutter :                 20px;
 
-/* pillar colours */
-$c-pillar--news      : #e00000;
-$c-pillar--opinion   : #ed6300;
-$c-pillar--sport     : #0084c6;
-$c-pillar--arts      : #ab8958;
-$c-pillar--lifestyle : #bb3b80;
-
 /* colours */
 $guardian-brand :         #005689;
 $guardian-brand-light :   #94b1ca;

--- a/core/src/main/resources/css/atoms/_snippet.scss
+++ b/core/src/main/resources/css/atoms/_snippet.scss
@@ -38,17 +38,7 @@
 
 .atom--snippet__label {
     display: block;
-
-    .garnett--pillar-news      &,
-    .content--pillar-news      & { color: $c-pillar--news; }
-    .garnett--pillar-arts      &,
-    .content--pillar-arts      & { color: $c-pillar--arts; }
-    .garnett--pillar-sport     &,
-    .content--pillar-sport     & { color: $c-pillar--sport; }
-    .garnett--pillar-opinion   &,
-    .content--pillar-opinion   & { color: $c-pillar--opinion; }
-    .garnett--pillar-lifestyle &,
-    .content--pillar-lifestyle & { color: $c-pillar--lifestyle; }
+    color: var(--c-pillar--main);
 }
 
 .atom--snippet__label,
@@ -82,16 +72,7 @@
 .atom--snippet__feedback .atom__button:focus,
 .atom--snippet__handle:hover,
 .atom--snippet__handle:focus {
-    .garnett--pillar-news      &,
-    .content--pillar-news      & { background-color: $c-pillar--news; }
-    .garnett--pillar-arts      &,
-    .content--pillar-arts      & { background-color: $c-pillar--arts; }
-    .garnett--pillar-sport     &,
-    .content--pillar-sport     & { background-color: $c-pillar--sport; }
-    .garnett--pillar-opinion   &,
-    .content--pillar-opinion   & { background-color: $c-pillar--opinion; }
-    .garnett--pillar-lifestyle &,
-    .content--pillar-lifestyle & { background-color: $c-pillar--lifestyle; }    
+    background-color: var(--c-pillar--main); }
 }
 
 .atom--snippet__handle span {

--- a/core/src/main/resources/css/email/snippets.scss
+++ b/core/src/main/resources/css/email/snippets.scss
@@ -29,11 +29,11 @@ p {
 }
 
 .atom--snippet__label {
-  color: $c-pillar--news;
+  color: var(--c-pillar--main);
 }
 
 .atom--snippet__rule {
-  background: $c-pillar--news content-box;
+  background: var(--c-pillar--main) content-box;
 }
 
 .atom--snippet__image {
@@ -46,7 +46,7 @@ p {
 }
 
 .atom--snippet__body a {
-  color: $c-pillar--news;
+  color: var(--c-pillar--main);
   text-decoration-color: $neutral-4;
   text-decoration-skip-ink: auto; 
 }

--- a/core/src/main/resources/storyquestions/article/index.scss
+++ b/core/src/main/resources/storyquestions/article/index.scss
@@ -17,17 +17,7 @@
   font-family: var(--f-serif-headline);
   font-weight: 500;
   margin-bottom: 0;
-
-  .garnett--pillar-news      &,
-  .content--pillar-news      & { color: $c-pillar--news; }
-  .garnett--pillar-arts      &,
-  .content--pillar-arts      & { color: $c-pillar--arts; }
-  .garnett--pillar-sport     &,
-  .content--pillar-sport     & { color: $c-pillar--sport; }
-  .garnett--pillar-opinion   &,
-  .content--pillar-opinion   & { color: $c-pillar--opinion; }
-  .garnett--pillar-lifestyle &,
-  .content--pillar-lifestyle & { color: $c-pillar--lifestyle; }
+  color: var(--c-pillar--main);
 }
 
 .atom--readerquestions .atom--readerquestions__description {
@@ -82,16 +72,7 @@
   .atom--readerquestions__form &:hover,
   .atom--readerquestions__form &:focus,
   .atom--readerquestions__form &:active {
-    .garnett--pillar-news      &,
-    .content--pillar-news      & { background-color: $c-pillar--news; }
-    .garnett--pillar-arts      &,
-    .content--pillar-arts      & { background-color: $c-pillar--arts; }
-    .garnett--pillar-sport     &,
-    .content--pillar-sport     & { background-color: $c-pillar--sport; }
-    .garnett--pillar-opinion   &,
-    .content--pillar-opinion   & { background-color: $c-pillar--opinion; }
-    .garnett--pillar-lifestyle &,
-    .content--pillar-lifestyle & { background-color: $c-pillar--lifestyle; }
+    background-color: var(--c-pillar--main);
   }
 }
 


### PR DESCRIPTION
As a design principle, the atom library should hold off as few information as possible and delegate any choice over to the platform. This is exactly the same reasoning as with polymorphism vs monomorphism, i.e. by making a function more polymorphic, we restrict the things it can do with its argument.

In this example, we require the host platform to provide colour information, as these things usually are tweaked locally to accommodate software or hardware specifications. (Ultimately, we don't want _any_ SASS variable that might otherwise be provided by the platform)