### PR TITLE
Encode HTML entities in XML

### DIFF
--- a/core/src/main/scala/renderers/email/Hydrator.scala
+++ b/core/src/main/scala/renderers/email/Hydrator.scala
@@ -47,7 +47,7 @@ object Hydrator {
       .escapeMode(Entities.EscapeMode.xhtml)
     rules.foreach(run(doc, _)) // ಥ﹏ಥ
     doc
-      .outputSettings(doc.outputSettings.syntax(Document.OutputSettings.Syntax.xml))
+      .outputSettings(settings)
       .charset(java.nio.charset.StandardCharsets.UTF_8)
     doc.body.html
   }

--- a/core/src/main/scala/renderers/email/Hydrator.scala
+++ b/core/src/main/scala/renderers/email/Hydrator.scala
@@ -3,7 +3,7 @@ package renderers
 package email
 
 import org.jsoup.Jsoup
-import org.jsoup.nodes.{ Document, Element }
+import org.jsoup.nodes.{ Document, Element, Entities }
 import org.jsoup.safety.Whitelist
 
 import collection.JavaConverters._
@@ -42,6 +42,9 @@ object Hydrator {
   def apply(html: String, css: String): String = {
     val doc = document(html)
     val rules = stylesheet(css)
+    val settings = doc.outputSettings
+      .syntax(Document.OutputSettings.Syntax.xml)
+      .escapeMode(Entities.EscapeMode.xhtml)
     rules.foreach(run(doc, _)) // ಥ﹏ಥ
     doc
       .outputSettings(doc.outputSettings.syntax(Document.OutputSettings.Syntax.xml))


### PR DESCRIPTION
An XML processor does not understand named entity references like `&nbsp;` if they are not defined first. That alone is a whole conundrum, but fortunately there's an easy way around it: use entity references instead, i.e. `&#x00A0;`, and jsoup provides a nice API to take care of this for us.