### PR TITLE
Snippet email fixes

### DIFF
--- a/core/src/main/resources/css/email/snippets.scss
+++ b/core/src/main/resources/css/email/snippets.scss
@@ -28,12 +28,12 @@ p {
   width: 600px;
 }
 
-.atom--snippet__label {
-  color: var(--c-pillar--main);
+.atom--snippet__main {
+  border-top: 1px solid var(--c-pillar--main);
 }
 
-.atom--snippet__rule {
-  background: var(--c-pillar--main) content-box;
+.atom--snippet__label {
+  color: var(--c-pillar--main);
 }
 
 .atom--snippet__image {

--- a/core/src/main/resources/fragments/email/snippet.scala.html
+++ b/core/src/main/resources/fragments/email/snippet.scala.html
@@ -8,9 +8,8 @@
       <p>Earlier you voted for one of three questions. We now have an answer to the most popular one for you.</p>
     </td>
   </tr>
-  <tr>
-    <td height="1" class="atom--snippet__rule"></td>
-  </tr>
+</table>
+<table class="atom--snippet__main" cellspacing="0" cellpadding="10" border="0">
   <tr>
     <td width="580">
       <h1 class="atom--snippet__label">@label</h1>

--- a/core/src/main/resources/guide/email/index.scala.html
+++ b/core/src/main/resources/guide/email/index.scala.html
@@ -11,7 +11,7 @@
   ){ 
     <table cellspacing="0" cellpadding="0" border="0">
       <tr>
-        <td width="100">
+        <td width="100" valign="top">
           @for(
             img <- data.guideImage 
           ) { 

--- a/core/src/main/resources/profile/email/index.scala.html
+++ b/core/src/main/resources/profile/email/index.scala.html
@@ -11,7 +11,7 @@
   ){ 
     <table cellspacing="0" cellpadding="0" border="0">
       <tr>
-        <td width="100">
+        <td width="100" valign="top">
           @for(
             img <- data.headshot 
           ) { 

--- a/core/src/main/resources/qanda/email/index.scala.html
+++ b/core/src/main/resources/qanda/email/index.scala.html
@@ -11,7 +11,7 @@
   ){ 
     <table cellspacing="0" cellpadding="0" border="0">
       <tr>
-        <td width="100">
+        <td width="100" valign="top">
           @for(
             img <- data.eventImage 
           ) { 


### PR DESCRIPTION
Based on visual feedback, two things need fixing:

![screen shot 2018-02-07 at 14 46 59](https://user-images.githubusercontent.com/629976/35924715-b422b652-0c1b-11e8-980e-2bdf5eea8414.png)

1- there is a missing 1px rule between the introductory paragraph and the content of the snippet
2- the image must be aligned with the top of the text