### PR TITLE
Commonsdivision atom - fix app style and make MP lists optional

### DIFF
--- a/core/src/main/resources/commonsdivision/article/index.scala.html
+++ b/core/src/main/resources/commonsdivision/article/index.scala.html
@@ -1,9 +1,10 @@
 @import com.gu.contentatom.renderer.utils.GuardianDateFormatter
 @import com.gu.contentatom.thrift.atom.commonsdivision.Mp
 
+@import com.gu.contentatom.renderer.ArticleConfiguration
 @(atom: com.gu.contentatom.thrift.Atom
 , data: com.gu.contentatom.thrift.atom.commonsdivision.CommonsDivision
-)
+)(implicit conf: ArticleConfiguration)
 
 @partyClassName(name: String) = @{
   val shortName = name match {
@@ -41,22 +42,26 @@
           <td>@ayes.get(partyName).map(_.length).getOrElse("-")</td>
           <td>@noes.get(partyName).map(_.length).getOrElse("-")</td>
           <td>
-            <button class="atom__button atom--commonsdivision__party-handle">
-              <span class="atom--commonsdivision__party-button">
-              @fragments.icons.html.plus()
-              </span>
-              <span class="atom--commonsdivision__party-button is-off">
-              @fragments.icons.html.minus()
-              </span>
-            </button>
+            @if(conf.commonsdivisionConfiguration.showMps) {
+              <button class="atom__button atom--commonsdivision__party-handle">
+                <span class="atom--commonsdivision__party-button">
+                @fragments.icons.html.plus()
+                </span>
+                <span class="atom--commonsdivision__party-button is-off">
+                @fragments.icons.html.minus()
+                </span>
+              </button>
+            }
           </td>
         </tr>
+        @if(conf.commonsdivisionConfiguration.showMps) {
         <tr class="atom--commonsdivision__party-mps is-off">
           <td></td>
           <td><ul>@ayes.getOrElse(partyName, Nil).map { mp => <li>@mp.name</li>}</ul></td>
           <td><ul>@noes.getOrElse(partyName, Nil).map { mp => <li>@mp.name</li>}</ul></td>
           <td></td>
         </tr>
+        }
       </tbody>
     }
     </table>

--- a/core/src/main/resources/commonsdivision/article/index.scss
+++ b/core/src/main/resources/commonsdivision/article/index.scss
@@ -103,7 +103,12 @@
   td, th {
     padding: 5px;
     background: transparent !important;
+    border-bottom: none;
   }
+}
+
+.atom--commonsdivision .atom--commonsdivision__table {
+  border-top: none;
 }
 
 .from-content-api .atom--commonsdivision__totals-table tr {
@@ -144,4 +149,8 @@
   li::before {
     content: none;
   }
+}
+
+.is-off {
+  display: none;
 }

--- a/core/src/main/scala/Configuration.scala
+++ b/core/src/main/scala/Configuration.scala
@@ -1,6 +1,6 @@
 package com.gu.contentatom.renderer
 
-import com.gu.contentatom.thrift.Atom
+import com.gu.contentatom.renderer.ArticleConfiguration.CommonsdivisionConfiguration
 
 sealed trait Configuration
 
@@ -8,8 +8,13 @@ sealed trait NilConfiguration extends Configuration
 case object NilConfiguration extends NilConfiguration
 
 final case class ArticleConfiguration(
-  ajaxUrl: String
+  ajaxUrl: String,
+  commonsdivisionConfiguration: CommonsdivisionConfiguration
 ) extends Configuration
+
+object ArticleConfiguration {
+  case class CommonsdivisionConfiguration(showMps: Boolean)
+}
 
 final case class EmailConfiguration(
   viewInBrowserUrl: String,

--- a/utils/src/main/scala/com.gu.contentatom.renderer/utils/CapiRenderer.scala
+++ b/utils/src/main/scala/com.gu.contentatom.renderer/utils/CapiRenderer.scala
@@ -5,8 +5,9 @@ import cats.Monad
 import cats.data.Kleisli
 import com.gu.contentapi.client.ContentApiClientLogic
 import com.gu.contentatom.thrift.{Atom, AtomType}
-
 import java.io._
+
+import com.gu.contentatom.renderer.ArticleConfiguration.CommonsdivisionConfiguration
 import monix.execution.Scheduler.Implicits.global
 import monix.eval.Task
 // -----------------------------------------------------------------------------
@@ -33,7 +34,7 @@ class IoCapiRenderer(_apiKey: String, _targetUrl: String = "https://content.guar
     override val targetUrl = _targetUrl
   }
 
-  val articleConfig = ArticleConfiguration("http://localhost")
+  val articleConfig = ArticleConfiguration("http://localhost", CommonsdivisionConfiguration(true))
   val emailConfig = EmailConfiguration(
     viewInBrowserUrl = "http://localhost",
     siteUrl = "http://localhost",


### PR DESCRIPTION
- Overrides some border styling in the app
- Adds a flag to disable the rendering of MP lists. This doesn't work properly on the app, and needs a better solution. For now we'll just hide it.