### PR TITLE
Hydrator: Do not clean the HTML input anymore

### DIFF
--- a/core/src/main/scala/renderers/email/Hydrator.scala
+++ b/core/src/main/scala/renderers/email/Hydrator.scala
@@ -17,7 +17,7 @@ object Hydrator {
     .addAttributes(":all", "align", "valign", "style", "class", "width", "height")
 
   def document: String => Document = 
-    doc => Jsoup.parse(Jsoup.clean(doc, whitelist))
+    doc => Jsoup.parse(doc)
 
   def stylesheet: String => List[CSSRuleset] =
     CSS.parseCss(_)


### PR DESCRIPTION
JSOUP provides a nice API to make sure the HTML that comes in is freed of anything we would not want such as attributes, elements, and even attribute values. In our use case, we need to add placeholders inside `href` attributes that ExactTarget can then substitute with a proper value, e.g. `<a href="%%unsubscribe%%">`. Sadly, these are not valid URLs and JSOUP will remove them during cleanup. As far as I know, there is no way to prevent that (I tried hacking the `withProtocols`).

We must then disable cleanup. It is not too bad, because this is first-party data and code we control end-to-end, it is unlikely there will ever be something wrong.