### PR TITLE
Set version 0.16.0-SNAPSHOT to match NPM library (already published)

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.15.1-SNAPSHOT"
+version in ThisBuild := "0.16.0-SNAPSHOT"


### PR DESCRIPTION
Following on from https://github.com/guardian/atom-renderer/pull/52 I was reluctant to run `sbt release` while the `version.sbt` file was out-of-sync with the npm library.

The docs suggest that the version in this file is used and then updated automatically, suggesting that it would publish as 0.15.1 which would be bad.

I have already `npm publish`ed 0.16.0 after merging the above PR, so I hope that we can get this wrapped up quickly in the morning and get on with our lives.

cc. @akash1810 in case you're still around and can advise :)
