### PR TITLE
Atom fonts: Fix scss variables

### DIFF
--- a/core/src/main/resources/css/_vars.scss
+++ b/core/src/main/resources/css/_vars.scss
@@ -9,6 +9,11 @@ $mq-breakpoints: (
   wide            : 1300px
 );
 
+/* fonts */
+
+$f-serif-headline:  "Guardian Egyptian Web", Georgia, serif;
+$f-sans-serif-text: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
+
 /* typography */
 $baseline :               12px;
 $gutter :                 20px;

--- a/core/src/main/resources/css/atoms/_snippet.scss
+++ b/core/src/main/resources/css/atoms/_snippet.scss
@@ -54,14 +54,14 @@
 .atom--snippet__label,
 .atom--snippet__headline {
     @include headline(3);
-    font-family: var(--f-serif-headline);
+    font-family: $f-serif-headline;
     font-weight: 500;
 }
 
 .atom--snippet__handle,
 .atom--snippet__feedback,
 .atom--snippet__credit {
-    font-family: var(--f-sans-serif-text);
+    font-family: $f-sans-serif-text;
 }
 
 .atom--snippet__handle {
@@ -168,7 +168,7 @@
 }
 
 .atom--snippet__heading {
-    font-family: var(--f-serif-headline);
+    font-family: $f-serif-headline;
     font-weight: 500;
 }
 


### PR DESCRIPTION
The fonts for atoms are not rendering correctly in Frontend. 

This is because they were undefined css variables and so just ended up as meaningless strings in frontend. 

I have changed them back to Scss variables in line with the rest of the code base. 

However I need a designer to confirm that the font strings are correct. 

![screen shot 2019-02-05 at 17 43 50](https://user-images.githubusercontent.com/10324129/52295615-3003a080-2974-11e9-954c-f8657b2d4eea.png)
