### PR TITLE
Use flexbox for inline player

### DIFF
--- a/core/src/main/resources/css/atoms/_audio.scss
+++ b/core/src/main/resources/css/atoms/_audio.scss
@@ -79,7 +79,7 @@
 }
 
 .atom--audio__body .atom--audio__time {
-  align-self: center;
+  align-items: center;
   display: flex;
   flex: 1;
 } 

--- a/core/src/main/resources/css/atoms/_audio.scss
+++ b/core/src/main/resources/css/atoms/_audio.scss
@@ -67,7 +67,6 @@
     background-color: $news-support-2;
 }
 
-/* CSS STYLES FOR AUDIO ATOM  - convert to Sass */
 .atom--audio__body {
   display: flex;
 }

--- a/core/src/main/resources/css/atoms/_audio.scss
+++ b/core/src/main/resources/css/atoms/_audio.scss
@@ -69,24 +69,19 @@
 
 /* CSS STYLES FOR AUDIO ATOM  - convert to Sass */
 .atom--audio__body {
-  display: grid;
-  grid-template-columns: 60px 1fr;
-  grid-gap: 10px;
-  grid-row: auto;
+  display: flex;
 }
 
 .atom--audio__body .atom--audio__controls {
-  grid-column: 1;
   padding-top: 10px;
+  padding-right: 10px;
+  width: 60px;
 }
 
 .atom--audio__body .atom--audio__time {
-  grid-column: 2/5;
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  grid-row: auto;
-  grid-gap: 10px;
-  align-items: center;
+  align-self: center;
+  display: flex;
+  flex: 1;
 } 
 
 .atom--audio__time span {
@@ -95,20 +90,19 @@
 }
 
 .atom--audio__progress-bar {
-  grid-column: 2;
-  width: auto;
+  flex: 1;
 }
 
 .atom--audio__time-played {
   min-width: 65px;
-  grid-column: 1;
+  padding-right: 10px;
   padding-top: 6px;
 }
 
 .atom--audio__time-duration {
   min-width: 65px;
-  grid-column: 3;
   padding-top: 6px;
+  padding-left: 10px;
 }
 
 .atom--audio__body button:focus {


### PR DESCRIPTION
Flexbox has more browser support in mobile, this is a defensive PR for devices running older OS versions. In a bare page, they render exactly the same, meaning all things being equal these changes are safe.

**Grid**
![screen shot 2019-02-11 at 10 28 15](https://user-images.githubusercontent.com/629976/52557573-c9eda200-2de7-11e9-951e-f99438e77db4.png)

**Flexbox**
![screen shot 2019-02-11 at 10 28 52](https://user-images.githubusercontent.com/629976/52557603-da9e1800-2de7-11e9-89e0-4e9e378d0bf5.png)
