### PR TITLE
Few fixes in the audio atom JS

### DIFF
--- a/core/src/main/resources/__flow__/types/ophan.fjs
+++ b/core/src/main/resources/__flow__/types/ophan.fjs
@@ -48,9 +48,17 @@ declare type Action = 'INSERT'
                     | 'SUBSCRIBE'
                     | 'ANSWER'
                     | 'VOTE'
-                    | 'CLICK'
-                    | 'PLAY'
-                    | 'READY';
+                    | 'CLICK';
+
+declare type MediaEvent = 'REQUEST'
+                        | 'READY'
+                        | 'PLAY'
+                        | 'PERCENT25'
+                        | 'PERCENT50'
+                        | 'PERCENT75'
+                        | 'THE_END'
+                        ;
+
 
 declare type AbTest = { name          : string
                       , variant       : string
@@ -65,7 +73,12 @@ declare type ComponentEvent = { component : ComponentV2
                               , abTest   ?: AbTest
                               };
 
-declare type OphanRecord = { componentEvent: ComponentEvent };
+declare type MediaAction = { id : string
+                           , eventType: string
+                           };
+
+declare type OphanRecord = { componentEvent: ComponentEvent }
+                         | { audio: MediaAction };
   
 declare interface OphanService {
   record: (x: OphanRecord) => void;

--- a/core/src/main/resources/lib/audio.fjs
+++ b/core/src/main/resources/lib/audio.fjs
@@ -1,6 +1,6 @@
 //@flow
 
-import { Actions } from 'ophan';
+import { Actions, MediaEvents } from 'ophan';
 import type { Channel } from 'channels';
 import { fromEvent } from 'events-getter';
 
@@ -38,6 +38,15 @@ function setupTime(dom: DomService, audio: Audio) {
     audio.scrubber.value = 0;
     audio.timePlayed.innerText = formatTime(0);
     audio.timeDuration.innerText = formatTime(Number(audio.player.getAttribute('data-duration')) || 0);
+  });
+}
+
+function recordOphanAudioEvent(id: string, eventName: string) {
+  ophan.record({
+    audio: {
+      id,
+      eventType: `audio:content:${eventName}`,
+    },
   });
 }
 
@@ -122,15 +131,6 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
     }
   };
 
-  const recordOphanAudioEvent = (id: string, eventName: string) => {
-    ophan.record({
-      audio: {
-        id,
-        eventType: `audio:content:${eventName}`,
-      },
-    });
-  };
-  
   const runTry = (): Try<Audio> => {
     const playPauseButton = (root.querySelector(playPauseButtonSelector): ?HTMLElement);
     const scrubber = (root.querySelector(progressSlider): ?HTMLElement);

--- a/core/src/main/resources/lib/audio.fjs
+++ b/core/src/main/resources/lib/audio.fjs
@@ -5,11 +5,11 @@ import type { Channel } from 'channels';
 import { fromEvent } from 'events-getter';
 
 type AudioF = { player: HTMLElement
-                , playPauseButton: HTMLElement
-                , timePlayed: HTMLElement
-                , timeDuration: HTMLElement
-                , scrubber: HTMLElement
-                };
+              , playPauseButton: HTMLElement
+              , timePlayed: HTMLElement
+              , timeDuration: HTMLElement
+              , scrubber: HTMLElement
+              };
 type Audio = AudioF & Atom;
 
 function setPlayingState(dom: DomService, playPauseButton: HTMLElement) {
@@ -102,6 +102,8 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
     observer = onVisible(a);
     viewport.observe(root, 1, observer);
 
+    recordOphanAudioEvent(a.player.getAttribute('data-media-id') || '', MediaEvents.READY);
+
     return Promise.resolve();
   };
   
@@ -133,7 +135,6 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
 
   const onVisible = (p: Audio) => (ratio: number): void => {
     if (ratio >= 1) {
-      recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.READY);
       setupTime(dom, p);
       viewport.unobserve(root, 1, observer);
     }

--- a/core/src/main/resources/lib/audio.fjs
+++ b/core/src/main/resources/lib/audio.fjs
@@ -88,6 +88,12 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
       .filter((e: ?HTMLButtonElement) => !!e);
     playPauseC.tap(onPlayPause(a));
 
+    const firstPlayC = fromEvent('click', a.playPauseButton)
+      .map((e: Event) => ((e.target: any).closest(playPauseButtonSelector): ?HTMLButtonElement))
+      .filter((e: ?HTMLButtonElement) => !!e)
+      .takeN(1);
+    playPauseC.tap(onFirstPlay(a));
+
     playerTimeUpdateC = fromEvent('timeupdate', a.player)
       .map((e: Event) => ((e.target: any).closest(audioPlayerSelector): ?HTMLElement))
       .filter((e: ?HTMLElement) => !!e);
@@ -105,9 +111,8 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
     viewport.unobserve(root, 1, observer);
   };
 
-  const onPlayPause = (p: Audio) => (a: Action): void => {
+  const onPlayPause = (p: Audio) => (b: HTMLButtonElement): void => {
     if (p.player.paused) {
-      recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.PLAY);
       setPlayingState(dom, p.playPauseButton);
       p.player.play();
       p.player.ontimeupdate = updateTime(dom, p);
@@ -116,6 +121,10 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
       p.player.pause();
     }
   };
+
+  const onFirstPlay = (p: Audio) => (b: HTMLButtonElement): void => {
+    recordOphanAudioEvent(p.player.getAttribute('data-media-id') || '', MediaEvents.PLAY);
+  }
 
   const onTick = (p: Audio) => (a: Action): void => {
     //TODO: send progress events to Ophan - needs thought re deduplication because it's based on percentage played

--- a/core/src/main/resources/lib/audio.fjs
+++ b/core/src/main/resources/lib/audio.fjs
@@ -4,8 +4,7 @@ import { Actions, MediaEvents } from 'ophan';
 import type { Channel } from 'channels';
 import { fromEvent } from 'events-getter';
 
-type AudioF = { audioId: string
-                , player: HTMLElement
+type AudioF = { player: HTMLElement
                 , playPauseButton: HTMLElement
                 , timePlayed: HTMLElement
                 , timeDuration: HTMLElement
@@ -75,13 +74,13 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
   let scrubC: Channel<Action>;
   let playerTimeUpdateC: Channel<Action>;
   let observer: (x: number) => void;
-  let audioContainerSelector = '.atom--audio';
-  let audioPlayerSelector = '.atom--audio__player-element';
-  let playPauseButtonSelector = '.atom--audio__button-playaudio';
-  let progressBarSelector = '.atom--audio__progress-bar';
-  let progressSlider = '.atom--audio__progress-bar > input';
-  let timePlayedSelector = '.atom--audio__time-played > span';
-  let timeDurationSelector = '.atom--audio__time-duration > span';
+  const audioContainerSelector = '.atom--audio';
+  const audioPlayerSelector = '.atom--audio__player-element';
+  const playPauseButtonSelector = '.atom--audio__button-playaudio';
+  const progressBarSelector = '.atom--audio__progress-bar';
+  const progressSlider = '.atom--audio__progress-bar > input';
+  const timePlayedSelector = '.atom--audio__time-played > span';
+  const timeDurationSelector = '.atom--audio__time-duration > span';
 
   const start = (a: Audio): Promise<void> => {
     playPauseC = fromEvent('click', a.playPauseButton)
@@ -102,7 +101,7 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
   
   const stop = () => {
     playPauseC.close();
-    scrubC.close();
+    playerTimeUpdateC.close();
     viewport.unobserve(root, 1, observer);
   };
 
@@ -139,7 +138,7 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
     const timePlayed = (root.querySelector(timePlayedSelector): ?HTMLElement);
     const timeDuration = (root.querySelector(timeDurationSelector): ?HTMLElement);
 
-    return audio && player && playPauseButton && timePlayed && scrubber
+    return audio && player && playPauseButton && timePlayed && timeDuration && scrubber
       ? Object.freeze({
         atomId: (root.dataset.atomId: string),
         player: player,

--- a/core/src/main/resources/lib/audio.fjs
+++ b/core/src/main/resources/lib/audio.fjs
@@ -52,6 +52,7 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
     audio.scrubber.removeEventListener('change', onTimeSeek);
     audio.player.removeEventListener('timeupdate', updateTime);
     audio.player.removeEventListener('ended', onPlaybackFinished);
+    audio = null;
   };
 
   const recordOphanAudioEvent = (id: string, eventName: string) => {

--- a/core/src/main/resources/lib/ophan.fjs
+++ b/core/src/main/resources/lib/ophan.fjs
@@ -49,7 +49,15 @@ export const Actions: { [Action]: Action } =
   , ANSWER: 'ANSWER'
   , VOTE: 'VOTE'
   , CLICK: 'CLICK'
-  , PLAY: 'PLAY'
+  };
+
+export const MediaEvents: { [MediaEvent]: MediaEvent } =
+  { REQUEST: 'REQUEST'
   , READY: 'READY'
+  , PLAY: 'PLAY'
+  , PERCENT25: 'PERCENT25'
+  , PERCENT50: 'PERCENT50'
+  , PERCENT75: 'PERCENT75'
+  , THE_END: 'THE_END'
   };
 


### PR DESCRIPTION
Brief summary:
- we keep `ComponentEvent` and `MediaEvent` separate, as they are in the Thrift model
- the PAUSE event does not exist
- reduce the number of closures by binding the `Audio` object once
- clean up _everything_ on `stop` to avoid memory leaks