### PR TITLE
Audio atom - add milestone events, time seeking and ad-free compatibility

### DIFF
--- a/core/src/main/resources/__flow__/types/ophan.fjs
+++ b/core/src/main/resources/__flow__/types/ophan.fjs
@@ -55,7 +55,7 @@ declare type Action = 'INSERT'
                     | 'PERCENT25'
                     | 'PERCENT50'
                     | 'PERCENT75'
-                    | 'THE_END'
+                    | 'THE_END';
 
 declare type AbTest = { name          : string
                       , variant       : string

--- a/core/src/main/resources/__flow__/types/ophan.fjs
+++ b/core/src/main/resources/__flow__/types/ophan.fjs
@@ -50,7 +50,12 @@ declare type Action = 'INSERT'
                     | 'VOTE'
                     | 'CLICK'
                     | 'PLAY'
-                    | 'READY';
+                    | 'READY'
+                    | 'PAUSE'
+                    | 'PERCENT25'
+                    | 'PERCENT50'
+                    | 'PERCENT75'
+                    | 'THE_END'
 
 declare type AbTest = { name          : string
                       , variant       : string

--- a/core/src/main/resources/audio/article/index.scala.html
+++ b/core/src/main/resources/audio/article/index.scala.html
@@ -2,45 +2,46 @@
 , data: com.gu.contentatom.thrift.atom.audio.AudioAtom
 )(implicit conf: com.gu.contentatom.renderer.ArticleConfiguration)
 
-@fragments.atoms.html.audio(
-    atom.id,
-    className = "podcast",
-    label = data.kicker,
-    headline = atom.title.getOrElse("")
-){
-    <audio
-    class="atom--audio__player-element"
-    data-duration="@data.duration"
-    src="@data.trackUrl"
-    preload="none"
-    data-media-id="@data.contentId"
-    data-title="@data.kicker"
-    data-component="inarticle audio"
-    >
+@defining(if(conf.useAcast && !conf.isAdFree) data.trackUrl.replace("https://","https://flex.acast.com/") else data.trackUrl) { srcUrl: String =>
+    @fragments.atoms.html.audio(
+        atom.id,
+        className = "podcast",
+        label = data.kicker,
+        headline = atom.title.getOrElse("")
+    ){
+        <audio
+        class="atom--audio__player-element"
+        data-duration="@data.duration"
+        src="@srcUrl"
+        preload="none"
+        data-media-id="@data.contentId"
+        data-title="@data.kicker"
+        data-component="inarticle audio"
+        >
         <p>
-            Sorry your browser does not support audio - but you can download here
-            and listen @data.trackUrl
+        Sorry your browser does not support audio - but you can download here
+        and listen @data.trackUrl
         </p>
-    </audio>
+        </audio>
 
-    <div class="atom--audio__controls">
+        <div class="atom--audio__controls">
         <button class="atom--audio__button-playaudio atom__button atom--audio__button--rounded atom--audio__handle">
-            @fragments.icons.html.playaudio()
-            @fragments.icons.html.pauseaudio()
+        @fragments.icons.html.playaudio()
+        @fragments.icons.html.pauseaudio()
         </button>
-    </div>
+        </div>
 
-    <div class="atom--audio__time">
+        <div class="atom--audio__time">
         <div class="atom--audio__time-played">
-            <span></span>
+        <span></span>
         </div>
         <div class="atom--audio__progress-bar">
-            <input type="range" min="0" max="100" step="1">
+        <input type="range" min="0" max="100" step="1">
         </div>
         <div class="atom--audio__time-duration">
-            <span></span>
+        <span></span>
         </div>
-    </div>
+        </div>
+
+    }
 }
-
-

--- a/core/src/main/resources/audio/article/index.scala.html
+++ b/core/src/main/resources/audio/article/index.scala.html
@@ -2,7 +2,7 @@
 , data: com.gu.contentatom.thrift.atom.audio.AudioAtom
 )(implicit conf: com.gu.contentatom.renderer.ArticleConfiguration)
 
-@defining(if(conf.useAcast && !conf.isAdFree) data.trackUrl.replace("https://","https://flex.acast.com/") else data.trackUrl) { srcUrl: String =>
+@defining(if(conf.audioSettings.externalAdvertising) data.trackUrl.replace("https://","https://flex.acast.com/") else data.trackUrl) { srcUrl: String =>
     @fragments.atoms.html.audio(
         atom.id,
         className = "podcast",

--- a/core/src/main/resources/lib/audio.fjs
+++ b/core/src/main/resources/lib/audio.fjs
@@ -26,19 +26,23 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
   let scrubC: Channel<Action>;
   let playerTimeUpdateC: Channel<Action>;
   let observer: (x: number) => void;
-  let audioContainerSelector = '.atom--audio';
-  let audioPlayerSelector = '.atom--audio__player-element';
-  let playPauseButtonSelector = '.atom--audio__button-playaudio';
-  let progressBarSelector = '.atom--audio__progress-bar';
-  let progressSlider = '.atom--audio__progress-bar > input';
-  let timePlayedSelector = '.atom--audio__time-played > span';
-  let timeDurationSelector = '.atom--audio__time-duration > span';
+  const audioContainerSelector = '.atom--audio';
+  const audioPlayerSelector = '.atom--audio__player-element';
+  const playPauseButtonSelector = '.atom--audio__button-playaudio';
+  const progressSliderSelector = '.atom--audio__progress-bar > input';
+  const timePlayedSelector = '.atom--audio__time-played > span';
+  const timeDurationSelector = '.atom--audio__time-duration > span';
 
   const start = (a: Audio): Promise<void> => {
     playPauseC = fromEvent('click', a.playPauseButton)
       .map((e: Event) => ((e.target: any).closest(playPauseButtonSelector): ?HTMLButtonElement))
       .filter((e: ?HTMLButtonElement) => !!e);
     playPauseC.tap(onPlayPause(a));
+
+    scrubC = fromEvent('click', a.scrubber)
+      .map((e: Event) => ((e.target: any).closest(progressSliderSelector): ?HTMLElement))
+      .filter((e: ?HTMLElement) => !!e);
+    scrubC.tap(onTimeSeek(a));
 
     playerTimeUpdateC = fromEvent('timeupdate', a.player)
       .map((e: Event) => ((e.target: any).closest(audioPlayerSelector): ?HTMLElement))
@@ -83,7 +87,18 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
       audio.scrubber.value = 0;
       audio.timePlayed.innerText = formatTime(0);
       audio.timeDuration.innerText = formatTime(Number(audio.player.getAttribute('data-duration')) || 0);
-      audio.player.setAttribute('milestones', 'READY');
+      audio.player.setAttribute('milestones', 'READY,');
+    });
+  };
+
+  const showProgress = (audio: Audio, percentPlayed: Number, now: Number, played: string) => {
+    const gradientDescription = `linear-gradient(to right, #C70000 ${percentPlayed}%, #afafaf ${percentPlayed}%)`;
+
+    dom.write(() => {
+      audio.scrubber.value = percentPlayed;
+      audio.player.setAttribute('last-tick', now.toString());
+      audio.scrubber.style.background = gradientDescription;
+      audio.timePlayed.innerText = formatTime(played);
     });
   };
 
@@ -97,48 +112,46 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
     const played = Math.floor(audio.player.currentTime);
     const duration = Number(audio.player.getAttribute('data-duration')) || 1; // avoid divide by zero if not present
     const percentPlayed = Math.floor(played / duration * 100);
-    const gradientDescription = `linear-gradient(to right, #C70000 ${percentPlayed}%, #afafaf ${percentPlayed}%)`;
     const milestones = audio.player.getAttribute('milestones');
 
     switch (percentPlayed){
       case 25: if (milestones.lastIndexOf('25%') < 0) {
-          audio.player.setAttribute('milestones', milestones.concat(',25%'));
-          recordOphanAudioEvent(audio.player.getAttribute('data-media-id'), Actions.PERCENT25);
-        }
+        audio.player.setAttribute('milestones', milestones.concat('25%,'));
+        recordOphanAudioEvent(audio.player.getAttribute('data-media-id'), Actions.PERCENT25);
+      }
         break;
       case 50: if (milestones.lastIndexOf('50%') < 0) {
-          audio.player.setAttribute('milestones', milestones.concat(',50%'));
-          recordOphanAudioEvent(audio.player.getAttribute('data-media-id'), Actions.PERCENT50);
-        }
+        audio.player.setAttribute('milestones', milestones.concat('50%,'));
+        recordOphanAudioEvent(audio.player.getAttribute('data-media-id'), Actions.PERCENT50);
+      }
         break;
       case 75: if (milestones.lastIndexOf('75%') < 0) {
-          audio.player.setAttribute('milestones', milestones.concat(',75%'));
-          recordOphanAudioEvent(audio.player.getAttribute('data-media-id'), Actions.PERCENT75);
-        }
+        audio.player.setAttribute('milestones', milestones.concat('75%,'));
+        recordOphanAudioEvent(audio.player.getAttribute('data-media-id'), Actions.PERCENT75);
+      }
         break;
-      case 100: if (milestones.lastIndexOf('THE_END') < 0) {
-          audio.player.setAttribute('milestones', milestones.concat(',THE_END'));
-          recordOphanAudioEvent(audio.player.getAttribute('data-media-id'), Actions.THE_END);
-        }
+      case 99: if (milestones.lastIndexOf('THE_END') < 0) {
+        audio.player.setAttribute('milestones', milestones.concat('THE_END,'));
+        recordOphanAudioEvent(audio.player.getAttribute('data-media-id'), Actions.THE_END);
+      }
     }
 
-    dom.write(() => {
-      audio.scrubber.value = percentPlayed;
-      audio.player.setAttribute('last-tick', now.toString());
-      audio.scrubber.style.background = gradientDescription;
-      audio.timePlayed.innerText = formatTime(played);
-    });
+    showProgress(audio, percentPlayed, now, played);
+
   };
 
   const onPlayPause = (p: Audio) => (a: Action): void => {
     if (p.player.paused) {
       setPlayingState(p.playPauseButton);
-      recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.PLAY);
       p.player.play();
       p.player.ontimeupdate = updateTime(p);
+      const milestones = p.player.getAttribute('milestones');
+      if (milestones.indexOf("PLAY") < 0 ) {
+        recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.PLAY);
+        p.player.setAttribute('milestones', milestones.concat('PLAY,'));
+      }
     } else {
       setPausedState(p.playPauseButton);
-      recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.PAUSE);
       p.player.pause();
     }
   };
@@ -155,9 +168,18 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
     }
   };
 
+  const onTimeSeek = (p: Audio) => (a: Action): void => {
+    const percentSought = Number(p.scrubber.value) || 0;
+    const duration = Number(p.player.getAttribute('data-duration'));
+    const played = Math.floor(duration * percentSought / 100);
+    const now = Date.now();
+    p.player.currentTime = played;
+    showProgress(p, percentSought, now, played);
+  };
+
   const runTry = (): Try<Audio> => {
     const playPauseButton = (root.querySelector(playPauseButtonSelector): ?HTMLElement);
-    const scrubber = (root.querySelector(progressSlider): ?HTMLElement);
+    const scrubber = (root.querySelector(progressSliderSelector): ?HTMLElement);
     const audio = (root.querySelector(audioContainerSelector): ?HTMLElement);
     const player = (root.querySelector(audioPlayerSelector): ?HTMLElement);
     const timePlayed = (root.querySelector(timePlayedSelector): ?HTMLElement);

--- a/core/src/main/resources/lib/audio.fjs
+++ b/core/src/main/resources/lib/audio.fjs
@@ -13,52 +13,12 @@ type AudioF = { audioId: string
                 };
 type Audio = AudioF & Atom;
 
-function setPlayingState(dom: DomService, playPauseButton: HTMLElement) {
-  dom.write(() => {
-    playPauseButton.classList.add('is-playing');
-  });
-}
-
-function setPausedState(dom: DomService, playPauseButton: HTMLElement) {
-  dom.write(() => {
-    playPauseButton.classList.remove('is-playing');
-  });
-}
-
 function formatTime(t: number): string {
   const format = (t: number) => t.toFixed(0).padStart(2, '0');
   const second = Math.floor(t % 60);
   const minute = Math.floor((t % 3600) / 60);
   const hour = Math.floor(t / 3600);
   return `${format(hour)}:${format(minute)}:${format(second)}`;
-}
-
-function setupTime(dom: DomService, audio: Audio) {
-  dom.write(() => {
-    audio.scrubber.value = 0;
-    audio.timePlayed.innerText = formatTime(0);
-    audio.timeDuration.innerText = formatTime(Number(audio.player.getAttribute('data-duration')) || 0);
-  });
-}
-
-function updateTime(dom: DomService, audio: Audio) {
-  const now = Date.now();
-  const last = audio.player.getAttribute('last-tick');
-
-  // throttle to 1 update per second
-  if (now - (Number(last) || 0) < 1000) return;
-
-  const played = Math.floor(audio.player.currentTime);
-  const duration = Number(audio.player.getAttribute('data-duration')) || 1; // avoid divide by zero if not present
-  const percentPlayed = Math.floor(played / duration * 100);
-  const gradientDescription = `linear-gradient(to right, #C70000 ${percentPlayed}%, #afafaf ${percentPlayed}%)`;
-
-  dom.write(() => {
-    audio.scrubber.value = percentPlayed;
-    audio.player.setAttribute('last-tick', now.toString());
-    audio.scrubber.style.background = gradientDescription;
-    audio.timePlayed.innerText = formatTime(played);
-  });
 }
 
 export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Services): AtomBuilder<AudioF> => (root: HTMLElement): Coeval<Audio> => {
@@ -97,31 +57,6 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
     viewport.unobserve(root, 1, observer);
   };
 
-  const onPlayPause = (p: Audio) => (a: Action): void => {
-    if (p.player.paused) {
-      recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.PLAY);
-      setPlayingState(dom, p.playPauseButton);
-      p.player.play();
-      p.player.ontimeupdate = updateTime(dom, p);
-    } else {
-      setPausedState(dom, p.playPauseButton);
-      p.player.pause();
-    }
-  };
-
-  const onTick = (p: Audio) => (a: Action): void => {
-    //TODO: send progress events to Ophan - needs thought re deduplication because it's based on percentage played
-    updateTime(dom, p);
-  };
-
-  const onVisible = (p: Audio) => (ratio: number): void => {
-    if (ratio >= 1) {
-      recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.READY);
-      setupTime(dom, p);
-      viewport.unobserve(root, 1, observer);
-    }
-  };
-
   const recordOphanAudioEvent = (id: string, eventName: string) => {
     ophan.record({
       audio: {
@@ -130,7 +65,96 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
       },
     });
   };
-  
+
+  const setPlayingState = (playPauseButton: HTMLElement) => {
+    dom.write(() => {
+      playPauseButton.classList.add('is-playing');
+    });
+  };
+
+  const setPausedState = (playPauseButton: HTMLElement) => {
+    dom.write(() => {
+      playPauseButton.classList.remove('is-playing');
+    });
+  };
+
+  const setupTime = (audio: Audio) => {
+    dom.write(() => {
+      audio.scrubber.value = 0;
+      audio.timePlayed.innerText = formatTime(0);
+      audio.timeDuration.innerText = formatTime(Number(audio.player.getAttribute('data-duration')) || 0);
+      audio.player.setAttribute('milestones', 'READY');
+    });
+  };
+
+  const updateTime = (audio: Audio) => {
+    const now = Date.now();
+    const last = audio.player.getAttribute('last-tick');
+
+    // throttle to 1 update per second
+    if (now - (Number(last) || 0) < 1000) return;
+
+    const played = Math.floor(audio.player.currentTime);
+    const duration = Number(audio.player.getAttribute('data-duration')) || 1; // avoid divide by zero if not present
+    const percentPlayed = Math.floor(played / duration * 100);
+    const gradientDescription = `linear-gradient(to right, #C70000 ${percentPlayed}%, #afafaf ${percentPlayed}%)`;
+    const milestones = audio.player.getAttribute('milestones');
+
+    switch (percentPlayed){
+      case 25: if (milestones.lastIndexOf('25%') < 0) {
+          audio.player.setAttribute('milestones', milestones.concat(',25%'));
+          recordOphanAudioEvent(audio.player.getAttribute('data-media-id'), Actions.PERCENT25);
+        }
+        break;
+      case 50: if (milestones.lastIndexOf('50%') < 0) {
+          audio.player.setAttribute('milestones', milestones.concat(',50%'));
+          recordOphanAudioEvent(audio.player.getAttribute('data-media-id'), Actions.PERCENT50);
+        }
+        break;
+      case 75: if (milestones.lastIndexOf('75%') < 0) {
+          audio.player.setAttribute('milestones', milestones.concat(',75%'));
+          recordOphanAudioEvent(audio.player.getAttribute('data-media-id'), Actions.PERCENT75);
+        }
+        break;
+      case 100: if (milestones.lastIndexOf('THE_END') < 0) {
+          audio.player.setAttribute('milestones', milestones.concat(',THE_END'));
+          recordOphanAudioEvent(audio.player.getAttribute('data-media-id'), Actions.THE_END);
+        }
+    }
+
+    dom.write(() => {
+      audio.scrubber.value = percentPlayed;
+      audio.player.setAttribute('last-tick', now.toString());
+      audio.scrubber.style.background = gradientDescription;
+      audio.timePlayed.innerText = formatTime(played);
+    });
+  };
+
+  const onPlayPause = (p: Audio) => (a: Action): void => {
+    if (p.player.paused) {
+      setPlayingState(p.playPauseButton);
+      recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.PLAY);
+      p.player.play();
+      p.player.ontimeupdate = updateTime(p);
+    } else {
+      setPausedState(p.playPauseButton);
+      recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.PAUSE);
+      p.player.pause();
+    }
+  };
+
+  const onTick = (p: Audio) => (a: Action): void => {
+    updateTime(p);
+  };
+
+  const onVisible = (p: Audio) => (ratio: number): void => {
+    if (ratio >= 1) {
+      recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.READY);
+      setupTime(p);
+      viewport.unobserve(root, 1, observer);
+    }
+  };
+
   const runTry = (): Try<Audio> => {
     const playPauseButton = (root.querySelector(playPauseButtonSelector): ?HTMLElement);
     const scrubber = (root.querySelector(progressSlider): ?HTMLElement);

--- a/core/src/main/resources/lib/audio.fjs
+++ b/core/src/main/resources/lib/audio.fjs
@@ -136,7 +136,7 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
       p.player.play();
       p.player.ontimeupdate = updateTime(p);
       const milestones = p.player.getAttribute('data-milestones');
-      if (milestones.indexOf("PLAY") < 0 ) {
+      if (milestones.indexOf('PLAY') < 0 ) {
         recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.PLAY);
         p.player.setAttribute('data-milestones', milestones.concat('PLAY,'));
       }

--- a/core/src/main/resources/lib/audio.fjs
+++ b/core/src/main/resources/lib/audio.fjs
@@ -82,7 +82,7 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
       audio.scrubber.value = 0;
       audio.timePlayed.innerText = formatTime(0);
       audio.timeDuration.innerText = formatTime(Number(audio.player.getAttribute('data-duration')) || 0);
-      audio.player.setAttribute('milestones', 'READY,');
+      audio.player.setAttribute('data-milestones', 'READY,');
     });
   };
 
@@ -91,7 +91,7 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
 
     dom.write(() => {
       audio.scrubber.value = percentPlayed;
-      audio.player.setAttribute('last-tick', now.toString());
+      audio.player.setAttribute('data-last-tick', now.toString());
       audio.scrubber.style.background = gradientDescription;
       audio.timePlayed.innerText = formatTime(played);
     });
@@ -99,7 +99,7 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
 
   const updateTime = (p: Audio) => (): void => {
     const now = Date.now();
-    const last = p.player.getAttribute('last-tick');
+    const last = p.player.getAttribute('data-last-tick');
 
     // throttle to 1 update per second
     if (now - (Number(last) || 0) < 1000) return;
@@ -107,22 +107,22 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
     const played = Math.floor(p.player.currentTime);
     const duration = Number(p.player.getAttribute('data-duration')) || 1; // avoid divide by zero if not present
     const percentPlayed = Math.floor(played / duration * 100);
-    const milestones = p.player.getAttribute('milestones');
+    const milestones = p.player.getAttribute('data-milestones');
 
     if (percentPlayed >= 25 && milestones.lastIndexOf('25%') < 0){
-      p.player.setAttribute('milestones', milestones.concat('25%,'));
+      p.player.setAttribute('data-milestones', milestones.concat('25%,'));
       recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.PERCENT25);
     }
     if (percentPlayed >= 50 && milestones.lastIndexOf('50%') < 0){
-      p.player.setAttribute('milestones', milestones.concat('50%,'));
+      p.player.setAttribute('data-milestones', milestones.concat('50%,'));
       recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.PERCENT50);
     }
     if (percentPlayed >= 75 && milestones.lastIndexOf('75%') < 0){
-      p.player.setAttribute('milestones', milestones.concat('75%,'));
+      p.player.setAttribute('data-milestones', milestones.concat('75%,'));
       recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.PERCENT75);
     }
     if (percentPlayed >= 99 && milestones.lastIndexOf('THE_END') < 0){
-      p.player.setAttribute('milestones', milestones.concat('THE_END,'));
+      p.player.setAttribute('data-milestones', milestones.concat('THE_END,'));
       recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.THE_END);
     }
 
@@ -138,7 +138,7 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
       const milestones = p.player.getAttribute('milestones');
       if (milestones.indexOf("PLAY") < 0 ) {
         recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.PLAY);
-        p.player.setAttribute('milestones', milestones.concat('PLAY,'));
+        p.player.setAttribute('data-milestones', milestones.concat('PLAY,'));
       }
     } else {
       setPausedState(p.playPauseButton);

--- a/core/src/main/resources/lib/audio.fjs
+++ b/core/src/main/resources/lib/audio.fjs
@@ -22,8 +22,6 @@ function formatTime(t: number): string {
 }
 
 export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Services): AtomBuilder<AudioF> => (root: HTMLElement): Coeval<Audio> => {
-  let playPauseC: Channel<Action>;
-  let scrubC: Channel<Action>;
   let playerTimeUpdateC: Channel<Action>;
   let observer: (x: number) => void;
   const audioContainerSelector = '.atom--audio';
@@ -34,20 +32,18 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
   const timeDurationSelector = '.atom--audio__time-duration > span';
 
   const start = (a: Audio): Promise<void> => {
-    playPauseC = fromEvent('click', a.playPauseButton)
-      .map((e: Event) => ((e.target: any).closest(playPauseButtonSelector): ?HTMLButtonElement))
-      .filter((e: ?HTMLButtonElement) => !!e);
-    playPauseC.tap(onPlayPause(a));
-
-    scrubC = fromEvent('click', a.scrubber)
-      .map((e: Event) => ((e.target: any).closest(progressSliderSelector): ?HTMLElement))
-      .filter((e: ?HTMLElement) => !!e);
-    scrubC.tap(onTimeSeek(a));
+    /*
+      Safari 11+ doesn't recognise our handling of a click event intercepted over a Channel and therefore
+      refuses to start playback in response, so we're stuck with using the default addEventListener technique for now.
+    */
+    a.playPauseButton.addEventListener('click', onPlayPause(a));
+    a.scrubber.addEventListener('input', onTimeSeek(a));
+    a.scrubber.addEventListener('change', onTimeSeek(a));
 
     playerTimeUpdateC = fromEvent('timeupdate', a.player)
       .map((e: Event) => ((e.target: any).closest(audioPlayerSelector): ?HTMLElement))
       .filter((e: ?HTMLElement) => !!e);
-    playerTimeUpdateC.tap(onTick(a));
+    playerTimeUpdateC.tap(updateTime(a));
 
     observer = onVisible(a);
     viewport.observe(root, 1, observer);
@@ -56,8 +52,7 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
   };
   
   const stop = () => {
-    playPauseC.close();
-    scrubC.close();
+    playerTimeUpdateC.close();
     viewport.unobserve(root, 1, observer);
   };
 
@@ -102,45 +97,40 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
     });
   };
 
-  const updateTime = (audio: Audio) => {
+  const updateTime = (p: Audio) => (): void => {
     const now = Date.now();
-    const last = audio.player.getAttribute('last-tick');
+    const last = p.player.getAttribute('last-tick');
 
     // throttle to 1 update per second
     if (now - (Number(last) || 0) < 1000) return;
 
-    const played = Math.floor(audio.player.currentTime);
-    const duration = Number(audio.player.getAttribute('data-duration')) || 1; // avoid divide by zero if not present
+    const played = Math.floor(p.player.currentTime);
+    const duration = Number(p.player.getAttribute('data-duration')) || 1; // avoid divide by zero if not present
     const percentPlayed = Math.floor(played / duration * 100);
-    const milestones = audio.player.getAttribute('milestones');
+    const milestones = p.player.getAttribute('milestones');
 
-    switch (percentPlayed){
-      case 25: if (milestones.lastIndexOf('25%') < 0) {
-        audio.player.setAttribute('milestones', milestones.concat('25%,'));
-        recordOphanAudioEvent(audio.player.getAttribute('data-media-id'), Actions.PERCENT25);
-      }
-        break;
-      case 50: if (milestones.lastIndexOf('50%') < 0) {
-        audio.player.setAttribute('milestones', milestones.concat('50%,'));
-        recordOphanAudioEvent(audio.player.getAttribute('data-media-id'), Actions.PERCENT50);
-      }
-        break;
-      case 75: if (milestones.lastIndexOf('75%') < 0) {
-        audio.player.setAttribute('milestones', milestones.concat('75%,'));
-        recordOphanAudioEvent(audio.player.getAttribute('data-media-id'), Actions.PERCENT75);
-      }
-        break;
-      case 99: if (milestones.lastIndexOf('THE_END') < 0) {
-        audio.player.setAttribute('milestones', milestones.concat('THE_END,'));
-        recordOphanAudioEvent(audio.player.getAttribute('data-media-id'), Actions.THE_END);
-      }
+    if (percentPlayed >= 25 && milestones.lastIndexOf('25%') < 0){
+      p.player.setAttribute('milestones', milestones.concat('25%,'));
+      recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.PERCENT25);
+    }
+    if (percentPlayed >= 50 && milestones.lastIndexOf('50%') < 0){
+      p.player.setAttribute('milestones', milestones.concat('50%,'));
+      recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.PERCENT50);
+    }
+    if (percentPlayed >= 75 && milestones.lastIndexOf('75%') < 0){
+      p.player.setAttribute('milestones', milestones.concat('75%,'));
+      recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.PERCENT75);
+    }
+    if (percentPlayed >= 99 && milestones.lastIndexOf('THE_END') < 0){
+      p.player.setAttribute('milestones', milestones.concat('THE_END,'));
+      recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.THE_END);
     }
 
-    showProgress(audio, percentPlayed, now, played);
+    showProgress(p, percentPlayed, now, played);
 
   };
 
-  const onPlayPause = (p: Audio) => (a: Action): void => {
+  const onPlayPause = (p: Audio) => (): void => {
     if (p.player.paused) {
       setPlayingState(p.playPauseButton);
       p.player.play();
@@ -156,19 +146,15 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
     }
   };
 
-  const onTick = (p: Audio) => (a: Action): void => {
-    updateTime(p);
-  };
-
   const onVisible = (p: Audio) => (ratio: number): void => {
     if (ratio >= 1) {
-      recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.READY);
+      recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.VIEW);
       setupTime(p);
       viewport.unobserve(root, 1, observer);
     }
   };
 
-  const onTimeSeek = (p: Audio) => (a: Action): void => {
+  const onTimeSeek = (p: Audio) => (): void => {
     const percentSought = Number(p.scrubber.value) || 0;
     const duration = Number(p.player.getAttribute('data-duration'));
     const played = Math.floor(duration * percentSought / 100);

--- a/core/src/main/resources/lib/audio.fjs
+++ b/core/src/main/resources/lib/audio.fjs
@@ -135,7 +135,7 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
       setPlayingState(p.playPauseButton);
       p.player.play();
       p.player.ontimeupdate = updateTime(p);
-      const milestones = p.player.getAttribute('milestones');
+      const milestones = p.player.getAttribute('data-milestones');
       if (milestones.indexOf("PLAY") < 0 ) {
         recordOphanAudioEvent(p.player.getAttribute('data-media-id'), Actions.PLAY);
         p.player.setAttribute('data-milestones', milestones.concat('PLAY,'));

--- a/core/src/main/resources/lib/ophan.fjs
+++ b/core/src/main/resources/lib/ophan.fjs
@@ -51,5 +51,10 @@ export const Actions: { [Action]: Action } =
   , CLICK: 'CLICK'
   , PLAY: 'PLAY'
   , READY: 'READY'
+  , PAUSE: 'PAUSE'
+  , PERCENT25: 'PERCENT25'
+  , PERCENT50: 'PERCENT50'
+  , PERCENT75: 'PERCENT75'
+  , THE_END: 'THE_END'
   };
 

--- a/core/src/main/scala/Configuration.scala
+++ b/core/src/main/scala/Configuration.scala
@@ -7,10 +7,13 @@ sealed trait Configuration
 sealed trait NilConfiguration extends Configuration
 case object NilConfiguration extends NilConfiguration
 
+final case class AudioSettings(
+  externalAdvertising: Boolean
+)
+
 final case class ArticleConfiguration(
   ajaxUrl: String,
-  isAdFree: Boolean = false,
-  useAcast: Boolean = false,
+    audioSettings: AudioSettings,
   commonsdivisionConfiguration: CommonsdivisionConfiguration
 ) extends Configuration
 

--- a/core/src/main/scala/Configuration.scala
+++ b/core/src/main/scala/Configuration.scala
@@ -10,6 +10,7 @@ case object NilConfiguration extends NilConfiguration
 final case class ArticleConfiguration(
   ajaxUrl: String,
   isAdFree: Boolean = false,
+  useAcast: Boolean = false,
   commonsdivisionConfiguration: CommonsdivisionConfiguration
 ) extends Configuration
 

--- a/core/src/main/scala/Configuration.scala
+++ b/core/src/main/scala/Configuration.scala
@@ -9,6 +9,7 @@ case object NilConfiguration extends NilConfiguration
 
 final case class ArticleConfiguration(
   ajaxUrl: String,
+  isAdFree: Boolean = false,
   commonsdivisionConfiguration: CommonsdivisionConfiguration
 ) extends Configuration
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/atom-renderer",
-  "version": "0.16.1-justinpinner.test.3",
+  "version": "0.16.1",
   "description": "Platform-agnostic rendering library for atoms",
   "repository": "https://github.com/guardian/atom-renderer.git",
   "author": "Regis Kuckaertz <regis.kuckaertz@theguardian.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/atom-renderer",
-  "version": "0.16.1-justinpinner.test.1",
+  "version": "0.16.1-justinpinner.test.3",
   "description": "Platform-agnostic rendering library for atoms",
   "repository": "https://github.com/guardian/atom-renderer.git",
   "author": "Regis Kuckaertz <regis.kuckaertz@theguardian.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/atom-renderer",
-  "version": "0.16.0",
+  "version": "0.16.1-justinpinner.test.1",
   "description": "Platform-agnostic rendering library for atoms",
   "repository": "https://github.com/guardian/atom-renderer.git",
   "author": "Regis Kuckaertz <regis.kuckaertz@theguardian.com>",

--- a/utils/src/main/scala/com.gu.contentatom.renderer/utils/CapiRenderer.scala
+++ b/utils/src/main/scala/com.gu.contentatom.renderer/utils/CapiRenderer.scala
@@ -32,7 +32,7 @@ class IoCapiRenderer(_apiKey: String) extends Capi[Task] with CapiRenderer[Task]
 
   val client = new GuardianContentClient(_apiKey)
 
-  val articleConfig = ArticleConfiguration("http://localhost", CommonsdivisionConfiguration(true))
+  val articleConfig = ArticleConfiguration(ajaxUrl = "http://localhost", commonsdivisionConfiguration = CommonsdivisionConfiguration(true))
   val emailConfig = EmailConfiguration(
     viewInBrowserUrl = "http://localhost",
     siteUrl = "http://localhost",

--- a/utils/src/main/scala/com.gu.contentatom.renderer/utils/CapiRenderer.scala
+++ b/utils/src/main/scala/com.gu.contentatom.renderer/utils/CapiRenderer.scala
@@ -32,7 +32,12 @@ class IoCapiRenderer(_apiKey: String) extends Capi[Task] with CapiRenderer[Task]
 
   val client = new GuardianContentClient(_apiKey)
 
-  val articleConfig = ArticleConfiguration(ajaxUrl = "http://localhost", commonsdivisionConfiguration = CommonsdivisionConfiguration(true))
+  val audioSettings = AudioSettings(externalAdvertising = false)
+  val articleConfig = ArticleConfiguration(
+    ajaxUrl = "http://localhost",
+    audioSettings = audioSettings,
+    commonsdivisionConfiguration = CommonsdivisionConfiguration(true)
+  )
   val emailConfig = EmailConfiguration(
     viewInBrowserUrl = "http://localhost",
     siteUrl = "http://localhost",


### PR DESCRIPTION
Summary of changes for the audio atom;

- Now emits the milestone events for 25, 50 and 75%, and THE_END during playback
- Can be instructed to provide ad-free or Acast-wrapped audio source URLs
- Responds to user interaction with the progress bar, playing from the time selected (see graphic)

**Note: this version still carries the DEV version number, so don't merge until that's updated with the latest released version!**

Screenshots;
(captured locally) - there's a long-ish delay at 00:07:07 when the audio is first played - this is currently a known issue with audio playback

![audio-atom-with-extra-scrubbability](https://user-images.githubusercontent.com/690395/52576562-37b1c200-2e18-11e9-939a-4280b1a3b41a.gif)

