### PR TITLE
Potential part fix for Font problem 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,8 +2,7 @@ src
 build
 project
 target
-webpack
-!webpack/css.js
+webpack/atomTypes.js
 node_modules
 ensime*
 pc.stdout.log

--- a/webpack/css.js
+++ b/webpack/css.js
@@ -1,6 +1,6 @@
 module.exports = ({ cssVarsPath }) => [
   {
-    test: /stylesheets\/atoms\.scss$/,
+    test: /static\/src\/stylesheets\/atoms\/vars.scss$/,
     use: ['babel-loader', 'postcss-variables-loader', 'sass-loader']
   },
   {


### PR DESCRIPTION
Based on Simon Adcock's advice, have made a few amends to deal with the font problem of atoms in frontend:

The test is [testing a path](https://github.com/guardian/atom-renderer/blob/master/webpack/css.js#L3) that doesn’t exist in frontend. Should probably be testing for [this file](https://github.com/guardian/frontend/blob/master/static/src/stylesheets/atoms/vars.scss)

Additionally the [npmignore syntax](https://git-scm.com/docs/gitignore#_pattern_format) appears to be wrong:

```
An optional prefix "!" which negates the pattern; any matching file excluded by a previous pattern will become included again. It is not possible to re-include a file if a parent directory of that file is excluded. 
```
