### PR TITLE
Add some markup for easy detection

### DIFF
--- a/core/src/main/resources/chart/article/index.scala.html
+++ b/core/src/main/resources/chart/article/index.scala.html
@@ -1,6 +1,8 @@
+@import com.gu.contentatom.renderer.utils.Implicits._
 @(atom: com.gu.contentatom.thrift.Atom
 , data: com.gu.contentatom.thrift.atom.chart.ChartAtom
 )(implicit conf: com.gu.contentatom.renderer.ArticleConfiguration)
 
-
-<iframe srcdoc="@atom.defaultHtml" frameborder="0"></iframe>
+<div class="atom atom--chart">
+  <iframe name="@atom.id" class="atom__iframe" srcdoc="@data.newDefaultHtml(atom.defaultHtml)" src="#" frameborder="0"></iframe>
+</div>

--- a/core/src/main/scala/utils/RichImplicits.scala
+++ b/core/src/main/scala/utils/RichImplicits.scala
@@ -2,6 +2,7 @@ package com.gu.contentatom.renderer
 package utils
 
 import com.gu.contentatom.thrift.atom.audio.AudioAtom
+import com.gu.contentatom.thrift.atom.chart.ChartAtom
 import com.gu.contentatom.thrift.atom.timeline.TimelineItem
 import com.gu.contentatom.thrift.atom.storyquestions.StoryQuestionsAtom
 
@@ -31,6 +32,11 @@ object Implicits {
       val hours: Int   = audio.duration / 3600;
       f"$hours%02d:$minutes%02d:$seconds%02d"
     }
+  }
+
+  implicit class RichChart(val chart: ChartAtom) extends AnyVal {
+    def newDefaultHtml(html: String): String =
+      html.replace("<script>", "<gu-script>").replace("</script>", "</gu-script>")
   }
 
 }


### PR DESCRIPTION
Due to how chart atoms are currently working, we need to hack our way into the iframe resize algorithm. In order to do this, we must be able to (1) identify the iframe and (2) delay the resize event until after listeners have been registerd.

Point (1) is addressed by the `name` attribute. Point (2) is done by disabling all scripts in a crude way (replacing `script` with `gu-script` tags). On the platform size, event listeners are registers and then only is the `gu-script` -> `script` conversion done.

![chart](https://user-images.githubusercontent.com/629976/53351298-ed9d0600-3918-11e9-85b6-cfbebfc087dc.gif)
