### PR TITLE
Adjust audio and snippet atom label and headline font weights

### DIFF
--- a/core/src/main/resources/css/atoms/_audio.scss
+++ b/core/src/main/resources/css/atoms/_audio.scss
@@ -58,7 +58,14 @@
 .atom--audio__headline {
     @include headline(3);
     font-family: var(--f-serif-headline);
-    font-weight: 500;
+}
+
+.atom--audio__label {
+    font-weight: 600;
+}
+
+.atom--audio__headline {
+    font-weight: 400;
 }
 
 .atom--audio__body {

--- a/core/src/main/resources/css/atoms/_snippet.scss
+++ b/core/src/main/resources/css/atoms/_snippet.scss
@@ -55,7 +55,14 @@
 .atom--snippet__headline {
     @include headline(3);
     font-family: var(--f-serif-headline);
-    font-weight: 500;
+}
+
+.atom--snippet__label {
+    font-weight: 600;
+}
+
+.atom--snippet__headline {
+    font-weight: 400;
 }
 
 .atom--snippet__handle,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/atom-renderer",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Platform-agnostic rendering library for atoms",
   "repository": "https://github.com/guardian/atom-renderer.git",
   "author": "Regis Kuckaertz <regis.kuckaertz@theguardian.com>",


### PR DESCRIPTION
Adjust the label font weight up to 600 and the headline font weight down to 400 on audio and snippet atoms. See this [Trello card](https://trello.com/c/tSzKm3VM/626-audio-atom-and-snippet-atom-change-the-kicker-font-weight-to-600).

Initially I just adjusted the label font weight but that had a weird side effect of also making the headline font heavier too. For example;

**Original appearance (font weight 500 shared by both classes):**
![screen shot 2019-02-28 at 16 48 56](https://user-images.githubusercontent.com/690395/53630278-9c865e00-3c07-11e9-8b85-f97aa8021610.png)

**Interim appearance (label font weight 600, headline 500):**
![screen shot 2019-02-28 at 16 45 52](https://user-images.githubusercontent.com/690395/53630364-cd669300-3c07-11e9-849c-b98feba39fcc.png)

**Final appearance (label font weight 600, headline weight dropped to 400):**
![screen shot 2019-02-28 at 16 48 47](https://user-images.githubusercontent.com/690395/53630428-f5ee8d00-3c07-11e9-8530-697845be5bd2.png)

In all cases, the correct weight is shown in the dev tools for both elements, but the appearance was definitely different.





