### PR TITLE
Apply pillar colour to audio controls

### DIFF
--- a/core/src/main/resources/css/atoms/_audio.scss
+++ b/core/src/main/resources/css/atoms/_audio.scss
@@ -166,12 +166,30 @@ input[type=range]:focus {
 
 /* IE and FF slider input styling */
 .atom--audio__progress-bar input[type=range]::-ms-fill-lower {
-  background-color: #C70000;	
+  .garnett--pillar-news      &,
+  .content--pillar-news      & { background-color: linear-gradient(to right, $c-pillar--news 0%, #afafaf 0%); }
+  .garnett--pillar-arts      &,
+  .content--pillar-arts      & { background-color: linear-gradient(to right, $c-pillar--arts 0%, #afafaf 0%); }
+  .garnett--pillar-sport     &,
+  .content--pillar-sport     & { background-color: linear-gradient(to right, $c-pillar--sport 0%, #afafaf 0%); }
+  .garnett--pillar-opinion   &,
+  .content--pillar-opinion   & { background-color: linear-gradient(to right, $c-pillar--opinion 0%, #afafaf 0%); }
+  .garnett--pillar-lifestyle &,
+  .content--pillar-lifestyle & { background-color: linear-gradient(to right, $c-pillar--lifestyle 0%, #afafaf 0%); }
   height: 7px;
 }
 
 .atom--audio__progress-bar input[type=range]::-moz-range-progress {
-  background-color: #C70000;
+  .garnett--pillar-news      &,
+  .content--pillar-news      & { background-color: linear-gradient(to right, $c-pillar--news 0%, #afafaf 0%); }
+  .garnett--pillar-arts      &,
+  .content--pillar-arts      & { background-color: linear-gradient(to right, $c-pillar--arts 0%, #afafaf 0%); }
+  .garnett--pillar-sport     &,
+  .content--pillar-sport     & { background-color: linear-gradient(to right, $c-pillar--sport 0%, #afafaf 0%); }
+  .garnett--pillar-opinion   &,
+  .content--pillar-opinion   & { background-color: linear-gradient(to right, $c-pillar--opinion 0%, #afafaf 0%); }
+  .garnett--pillar-lifestyle &,
+  .content--pillar-lifestyle & { background-color: linear-gradient(to right, $c-pillar--lifestyle 0%, #afafaf 0%); }
   height: 8px;
 }
 

--- a/core/src/main/resources/css/atoms/_audio.scss
+++ b/core/src/main/resources/css/atoms/_audio.scss
@@ -54,6 +54,20 @@
     .content--pillar-lifestyle & { color: $c-pillar--lifestyle; }
 }
 
+.icon--play-button-svg > g > circle,
+.icon--pause-button-svg > g > circle {
+  .garnett--pillar-news      &,
+  .content--pillar-news      & { fill: $c-pillar--news; }
+  .garnett--pillar-arts      &,
+  .content--pillar-arts      & { fill: $c-pillar--arts; }
+  .garnett--pillar-sport     &,
+  .content--pillar-sport     & { fill: $c-pillar--sport; }
+  .garnett--pillar-opinion   &,
+  .content--pillar-opinion   & { fill: $c-pillar--opinion; }
+  .garnett--pillar-lifestyle &,
+  .content--pillar-lifestyle & { fill: $c-pillar--lifestyle; }
+}
+
 .atom--audio__label,
 .atom--audio__headline {
     @include headline(3);
@@ -135,7 +149,19 @@ input[type=range]:focus {
   width: 100%;
   cursor: pointer;
   height: 6px;
-  background: linear-gradient(to right, #C70000 0%, #afafaf 0%);
+}
+
+.atom--audio__progress-bar input[type=range] {
+  .garnett--pillar-news      &,
+  .content--pillar-news      & { background: linear-gradient(to right, $c-pillar--news 0%, #afafaf 0%); }
+  .garnett--pillar-arts      &,
+  .content--pillar-arts      & { background: linear-gradient(to right, $c-pillar--arts 0%, #afafaf 0%); }
+  .garnett--pillar-sport     &,
+  .content--pillar-sport     & { background: linear-gradient(to right, $c-pillar--sport 0%, #afafaf 0%); }
+  .garnett--pillar-opinion   &,
+  .content--pillar-opinion   & { background: linear-gradient(to right, $c-pillar--opinion 0%, #afafaf 0%); }
+  .garnett--pillar-lifestyle &,
+  .content--pillar-lifestyle & { background: linear-gradient(to right, $c-pillar--lifestyle 0%, #afafaf 0%); }
 }
 
 /* IE and FF slider input styling */
@@ -145,7 +171,7 @@ input[type=range]:focus {
 }
 
 .atom--audio__progress-bar input[type=range]::-moz-range-progress {
-   background-color: #C70000;	
+  background-color: #C70000;
   height: 8px;
 }
 
@@ -159,7 +185,6 @@ input[type=range]:focus {
   -moz-appearance: none;
   width: 15px;
   height: 15px;
-  background: #C70000;
   border-radius: 50%;
   margin-top: -4px;
   border: none;
@@ -175,7 +200,44 @@ input[type=range]:focus {
   -webkit-appearance: none;
   width: 15px;
   height: 15px;
-  background:#C70000;
   border-radius: 50%;
   margin-top: -4px;
+}
+
+// these non-standard pseudo selectors can't be comma-separated - so much duplication :(
+.atom--audio__progress-bar input[type=range]::-moz-range-thumb {
+  .garnett--pillar-news      &,
+  .content--pillar-news      & { background: $c-pillar--news; }
+  .garnett--pillar-arts      &,
+  .content--pillar-arts      & { background: $c-pillar--arts; }
+  .garnett--pillar-sport     &,
+  .content--pillar-sport     & { background: $c-pillar--sport; }
+  .garnett--pillar-opinion   &,
+  .content--pillar-opinion   & { background: $c-pillar--opinion; }
+  .garnett--pillar-lifestyle &,
+  .content--pillar-lifestyle & { background: $c-pillar--lifestyle; }
+}
+.atom--audio__progress-bar input[type=range]::-webkit-slider-thumb {
+  .garnett--pillar-news      &,
+  .content--pillar-news      & { background: $c-pillar--news; }
+  .garnett--pillar-arts      &,
+  .content--pillar-arts      & { background: $c-pillar--arts; }
+  .garnett--pillar-sport     &,
+  .content--pillar-sport     & { background: $c-pillar--sport; }
+  .garnett--pillar-opinion   &,
+  .content--pillar-opinion   & { background: $c-pillar--opinion; }
+  .garnett--pillar-lifestyle &,
+  .content--pillar-lifestyle & { background: $c-pillar--lifestyle; }
+}
+.atom--audio__progress-bar input[type=range]::-ms-thumb {
+  .garnett--pillar-news      &,
+  .content--pillar-news      & { background: $c-pillar--news; }
+  .garnett--pillar-arts      &,
+  .content--pillar-arts      & { background: $c-pillar--arts; }
+  .garnett--pillar-sport     &,
+  .content--pillar-sport     & { background: $c-pillar--sport; }
+  .garnett--pillar-opinion   &,
+  .content--pillar-opinion   & { background: $c-pillar--opinion; }
+  .garnett--pillar-lifestyle &,
+  .content--pillar-lifestyle & { background: $c-pillar--lifestyle; }
 }

--- a/core/src/main/resources/lib/audio.fjs
+++ b/core/src/main/resources/lib/audio.fjs
@@ -98,8 +98,9 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
   };
 
   const showProgress = (audio: Audio, percentPlayed: Number, now: Number, played: string) => {
-    // TODO: make the input control's background honour the pillar colour - meanwhile use the 'news' default
-    const gradientDescription = `linear-gradient(to right, #e00000 ${percentPlayed}%, #afafaf ${percentPlayed}%)`;
+    const css = getComputedStyle(audio.scrubber);
+    const cssBackgroundImage = css.getPropertyValue('background-image');
+    const gradientDescription = cssBackgroundImage.replace(/\d{1,3}%/gi, `${percentPlayed.toString()}%`);
 
     dom.write(() => {
       audio.scrubber.value = percentPlayed;

--- a/core/src/main/resources/lib/audio.fjs
+++ b/core/src/main/resources/lib/audio.fjs
@@ -83,7 +83,7 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
         action
       }
     });
-  }
+  };
   
   const setPlayingState = (playPauseButton: HTMLElement) => {
     dom.write(() => {
@@ -98,7 +98,8 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
   };
 
   const showProgress = (audio: Audio, percentPlayed: Number, now: Number, played: string) => {
-    const gradientDescription = `linear-gradient(to right, #C70000 ${percentPlayed}%, #afafaf ${percentPlayed}%)`;
+    // TODO: make the input control's background honour the pillar colour - meanwhile use the 'news' default
+    const gradientDescription = `linear-gradient(to right, #e00000 ${percentPlayed}%, #afafaf ${percentPlayed}%)`;
 
     dom.write(() => {
       audio.scrubber.value = percentPlayed;


### PR DESCRIPTION
First pass to update the play/pause button and the slider thumb control to use the pillar colour.

We still have to find a way to make the progress bar apply the correct colour (or choose a neutral one) for the 'played' section. It's set by javascript and currently hard-coded to match the news pillar.

**Before**
![Screen Shot 2019-03-13 at 16 22 10](https://user-images.githubusercontent.com/690395/54296123-38bb4800-45ac-11e9-8ab5-3a1735dda542.png)
![Screen Shot 2019-03-13 at 16 22 19](https://user-images.githubusercontent.com/690395/54296136-3e189280-45ac-11e9-8d40-b39c1105daa7.png)

**After**
![Screen Shot 2019-03-13 at 15 46 13](https://user-images.githubusercontent.com/690395/54296020-09a4d680-45ac-11e9-8d68-2dea4265efe4.png)
![Screen Shot 2019-03-13 at 15 46 06](https://user-images.githubusercontent.com/690395/54296039-11647b00-45ac-11e9-86bd-6ef2ff68ed08.png)

