### PR TITLE
Update version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/atom-renderer",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "description": "Platform-agnostic rendering library for atoms",
   "repository": "https://github.com/guardian/atom-renderer.git",
   "author": "Regis Kuckaertz <regis.kuckaertz@theguardian.com>",


### PR DESCRIPTION
I forgot to increase the version no. in https://github.com/guardian/atom-renderer/pull/66 😞 