### PR TITLE
Use Firefox-specific CSS to draw background-image gradient on progress bar

### DIFF
--- a/core/src/main/resources/css/atoms/_audio.scss
+++ b/core/src/main/resources/css/atoms/_audio.scss
@@ -181,15 +181,15 @@ input[type=range]:focus {
 
 .atom--audio__progress-bar input[type=range]::-moz-range-progress {
   .garnett--pillar-news      &,
-  .content--pillar-news      & { background-color: linear-gradient(to right, $c-pillar--news 0%, #afafaf 0%); }
+  .content--pillar-news      & { background-image: linear-gradient(to right, $c-pillar--news 100%, #afafaf); }
   .garnett--pillar-arts      &,
-  .content--pillar-arts      & { background-color: linear-gradient(to right, $c-pillar--arts 0%, #afafaf 0%); }
+  .content--pillar-arts      & { background-image: linear-gradient(to right, $c-pillar--arts 100%, #afafaf); }
   .garnett--pillar-sport     &,
-  .content--pillar-sport     & { background-color: linear-gradient(to right, $c-pillar--sport 0%, #afafaf 0%); }
+  .content--pillar-sport     & { background-image: linear-gradient(to right, $c-pillar--sport 100%, #afafaf); }
   .garnett--pillar-opinion   &,
-  .content--pillar-opinion   & { background-color: linear-gradient(to right, $c-pillar--opinion 0%, #afafaf 0%); }
+  .content--pillar-opinion   & { background-image: linear-gradient(to right, $c-pillar--opinion 100%, #afafaf); }
   .garnett--pillar-lifestyle &,
-  .content--pillar-lifestyle & { background-color: linear-gradient(to right, $c-pillar--lifestyle 0%, #afafaf 0%); }
+  .content--pillar-lifestyle & { background-image: linear-gradient(to right, $c-pillar--lifestyle 100%, #afafaf); }
   height: 8px;
 }
 

--- a/core/src/main/resources/lib/audio.fjs
+++ b/core/src/main/resources/lib/audio.fjs
@@ -105,7 +105,7 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport }: Serv
     dom.write(() => {
       audio.scrubber.value = percentPlayed;
       audio.player.setAttribute('data-last-tick', now.toString());
-      audio.scrubber.style.background = gradientDescription;
+      audio.scrubber.style.backgroundImage = gradientDescription;
       audio.timePlayed.innerText = formatTime(played);
     });
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/atom-renderer",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "description": "Platform-agnostic rendering library for atoms",
   "repository": "https://github.com/guardian/atom-renderer.git",
   "author": "Regis Kuckaertz <regis.kuckaertz@theguardian.com>",


### PR DESCRIPTION
Restores background gradient fill on progress bar for Firefox browsers.

**Before:**
![Screen Shot 2019-03-20 at 14 11 16 - FF - BEFORE](https://user-images.githubusercontent.com/690395/54691715-a3740280-4b1b-11e9-9e62-fa06bf4b893c.png)

**After:**
![Screen Shot 2019-03-20 at 14 11 06 - FF - AFTER](https://user-images.githubusercontent.com/690395/54691724-a8d14d00-4b1b-11e9-838b-661e6d01d1a6.png)

Also re-tested (locally) with Chrome and Safari and they're still ok.

