### PR TITLE
Change MediaEvent values to match those expected by Ophan

### DIFF
--- a/core/src/main/resources/__flow__/types/ophan.fjs
+++ b/core/src/main/resources/__flow__/types/ophan.fjs
@@ -55,10 +55,10 @@ declare type Action = 'INSERT'
 declare type MediaEvent = 'REQUEST'
                         | 'READY'
                         | 'PLAY'
-                        | 'PERCENT25'
-                        | 'PERCENT50'
-                        | 'PERCENT75'
-                        | 'THE_END'
+                        | '25'
+                        | '50'
+                        | '75'
+                        | 'end'
                         ;
 
 

--- a/core/src/main/resources/lib/ophan.fjs
+++ b/core/src/main/resources/lib/ophan.fjs
@@ -56,9 +56,8 @@ export const MediaEvents: { [MediaEvent]: MediaEvent } =
   { REQUEST: 'REQUEST'
   , READY: 'READY'
   , PLAY: 'PLAY'
-  , PERCENT25: 'PERCENT25'
-  , PERCENT50: 'PERCENT50'
-  , PERCENT75: 'PERCENT75'
-  , THE_END: 'THE_END'
+  , PERCENT25: '25'
+  , PERCENT50: '50'
+  , PERCENT75: '75'
+  , THE_END: 'end'
   };
-

--- a/core/src/main/resources/lib/ophan.fjs
+++ b/core/src/main/resources/lib/ophan.fjs
@@ -52,7 +52,7 @@ export const Actions: { [Action]: Action } =
   , CLICK: 'CLICK'
   };
 
-export const MediaEvents: { [MediaEvent]: MediaEvent } =
+export const MediaEvents: { [string]: MediaEvent } =
   { REQUEST: 'REQUEST'
   , READY: 'READY'
   , PLAY: 'PLAY'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/atom-renderer",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "Platform-agnostic rendering library for atoms",
   "repository": "https://github.com/guardian/atom-renderer.git",
   "author": "Regis Kuckaertz <regis.kuckaertz@theguardian.com>",


### PR DESCRIPTION
Ophan translates incoming media events from e.g. `audio:content:25` into the form it expects e.g. `audio:content:PERCENT25`. We were originally emitting the latter, post-translated form, which Ophan couldn't deal with properly.

Now we'll output the pre-translated values that it _can_ understand and should be able to translate properly, so we should begin to see progress updates passing through all the way to the data lake 🤞 

