### PR TITLE
Use SPAN for the show/hide element

### DIFF
--- a/core/src/main/resources/css/atoms/_buttons.scss
+++ b/core/src/main/resources/css/atoms/_buttons.scss
@@ -1,4 +1,5 @@
 .atom__button {
+  cursor: pointer;
   display: inline-flex;
   align-items: center;
   border: 0;

--- a/core/src/main/resources/fragments/atoms/snippet.scala.html
+++ b/core/src/main/resources/fragments/atoms/snippet.scala.html
@@ -4,10 +4,10 @@
   <summary class="atom--snippet__header">
     <span class="atom--snippet__label">@label</span>
     <h4 class="atom--snippet__headline">@headline</h4>
-    <button class="atom__button atom__button--large atom__button--rounded atom--snippet__handle" aria-hidden="true">
+    <span class="atom__button atom__button--large atom__button--rounded atom--snippet__handle" aria-hidden="true">
       <span class="is-on">@fragments.icons.html.plus() Show</span>
       <span class="is-off">@fragments.icons.html.minus() Hide</span>
-    </button>
+    </span>
   </summary>
   <div class="atom--snippet__body">
     @body


### PR DESCRIPTION
Clicks on `BUTTON` elements inside a `SUMMARY` will not propagate events such that the behaviour of the surrounding `DETAILS` is preserved, not in Firefox.

As a result, people have been complaining that they can't open snippets when they hit the "Show" button. To fix that, we use a simple `SPAN` instead.