### PR TITLE
Bump version number in package.json and version.sbt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/atom-renderer",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Platform-agnostic rendering library for atoms",
   "repository": "https://github.com/guardian/atom-renderer.git",
   "author": "Regis Kuckaertz <regis.kuckaertz@theguardian.com>",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.2-SNAPSHOT"
+version in ThisBuild := "1.1.3-SNAPSHOT"


### PR DESCRIPTION
I forgot to do this as part of https://github.com/guardian/atom-renderer/pull/77 