### PR TITLE
Correct implementation of durationStr

### DIFF
--- a/core/src/main/scala/utils/RichImplicits.scala
+++ b/core/src/main/scala/utils/RichImplicits.scala
@@ -19,9 +19,10 @@ object Implicits {
 
   implicit class RichAudio(val audio: AudioAtom) extends AnyVal {
     def durationStr: String = {
-      val seconds: Int = audio.duration % 60;
-      val minutes: Int = Math.min(59, audio.duration / 60);
-      val hours: Int   = audio.duration / 3600;
+      val duration = audio.duration
+      val hours = duration / 3600
+      val minutes = (duration - hours*3600) / 60
+      val seconds = duration - hours*3600 - minutes*60
       f"$hours%02d:$minutes%02d:$seconds%02d"
     }
   }


### PR DESCRIPTION
The correct implementation of function `durationStr` is incorrect. 

(This was noticed by the fact that some videos on the site shows a sudden jump from the originally displayed time, which is the output of `durationStr`, to the correct time after one clicked on play. Example: https://www.theguardian.com/football/2020/jan/20/the-fiver-alan-pardew-chris-powell-den-haag-ghostbusters).

Starting with a duration of `3802` ( The duration carried by the AudioAtom on the above page ) the current implementation behave like this:

```
duration = 3802
seconds = duration % 60
minutes = [ 59, duration / 60 ].min
hours   = duration / 3600

(hours, minutes, seconds) -> (1,59,22) # Incorrect! 
```
 
The correct code proposed change, does this

```
duration = 3802
hours   = duration / 3600
minutes = ( duration - hours*3600 ) / 60
seconds = duration - hours*3600 - minutes*60

(hours, minutes, seconds) -> (1, 3, 22) # Correct
```

