### PR TITLE
Change Acast consent type to Promise

### DIFF
--- a/core/src/main/resources/__flow__/types/global.fjs
+++ b/core/src/main/resources/__flow__/types/global.fjs
@@ -3,7 +3,7 @@
 declare type Services = { ophan: OphanService
                         , dom: DomService
                         , viewport: ViewportService
-                        , consent: { acast: boolean; }
+                        , consent: { acast: Promise<boolean>; }
                         , commercial: { isAdFree: boolean; } 
                         };
 

--- a/core/src/main/resources/lib/audio.fjs
+++ b/core/src/main/resources/lib/audio.fjs
@@ -198,13 +198,17 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport, consen
     const timeDuration = (root.querySelector(timeDurationSelector): ?HTMLElement);
 
     // Use Acast (advertising service) based on consent and ad-free status.
-    if (consent.acast && !commercial.isAdFree && player) {
-      const srcUrl =player.getAttribute('src');
-      if (srcUrl) {
-        dom.write(() => {
-          player.setAttribute('src', srcUrl.replace("https://","https://flex.acast.com/"));
-        });
-      }
+    if (!commercial.isAdFree) {
+      consent.acast.then(acast => {
+        if (player && acast) {
+          const srcUrl =player.getAttribute('src');
+          if (srcUrl) {
+            dom.write(() => {
+              player.setAttribute('src', srcUrl.replace("https://","https://flex.acast.com/"));
+            });
+          }
+        }
+      })
     }
 
     return audio && player && playPauseButton && timePlayed && timeDuration && scrubber

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/atom-renderer",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Platform-agnostic rendering library for atoms",
   "repository": "https://github.com/guardian/atom-renderer.git",
   "author": "Regis Kuckaertz <regis.kuckaertz@theguardian.com>",

--- a/utils/src/main/twirl/com.gu.contentatom.renderer.utils/page.scala.html
+++ b/utils/src/main/twirl/com.gu.contentatom.renderer.utils/page.scala.html
@@ -95,7 +95,7 @@
             unobserve
           },
           consent: {
-            acast: true,
+            acast: Promise.resolve(true),
           },
           commercial: {
             isAdFree: false,


### PR DESCRIPTION
...as clients calling this only have access to the value as a promise typically. (I.e. this is how the consent-management-platform library works.)
