### PR TITLE
Use callback for Acast (audio ads) consent

### DIFF
--- a/core/src/main/resources/__flow__/types/global.fjs
+++ b/core/src/main/resources/__flow__/types/global.fjs
@@ -3,7 +3,7 @@
 declare type Services = { ophan: OphanService
                         , dom: DomService
                         , viewport: ViewportService
-                        , consent: { acast: Promise<boolean>; }
+                        , consent: { onAcastConsentChange: (callback: boolean => void) => void }
                         , commercial: { isAdFree: boolean; } 
                         };
 

--- a/core/src/main/resources/lib/audio.fjs
+++ b/core/src/main/resources/lib/audio.fjs
@@ -199,7 +199,9 @@ export default (componentType: ComponentType) => ({ ophan, dom, viewport, consen
 
     // Use Acast (advertising service) based on consent and ad-free status.
     if (!commercial.isAdFree) {
-      consent.acast.then(acast => {
+      consent.onAcastConsentChange(acast => {
+        const player = ((root.querySelector(audioPlayerSelector): any): ?HTMLMediaElement);
+        
         if (player && acast) {
           const srcUrl =player.getAttribute('src');
           if (srcUrl) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/atom-renderer",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Platform-agnostic rendering library for atoms",
   "repository": "https://github.com/guardian/atom-renderer.git",
   "author": "Regis Kuckaertz <regis.kuckaertz@theguardian.com>",

--- a/utils/src/main/twirl/com.gu.contentatom.renderer.utils/page.scala.html
+++ b/utils/src/main/twirl/com.gu.contentatom.renderer.utils/page.scala.html
@@ -95,7 +95,7 @@
             unobserve
           },
           consent: {
-            acast: Promise.resolve(true),
+            onAcastConsentChange: (callback) => { callback(true); },
           },
           commercial: {
             isAdFree: false,


### PR DESCRIPTION
Required as consent is not set once but can change multiple times on a single page. In fact, because of the way the consent library works this always happens.